### PR TITLE
add state_of_css 2023 japanese translation

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -876,37 +876,37 @@ translations:
     t: 製造
 
   - key: options.industry_sector.tech_it
-    t: Tech & IT
+    t: テック＆IT
   - key: options.industry_sector.human_resources
-    t: Human Resources
+    t: 人事・人材
   - key: options.industry_sector.sports
-    t: Sports
+    t: スポーツ
   - key: options.industry_sector.gaming
-    t: Gaming
+    t: ゲーム
   - key: options.industry_sector.research
-    t: Research
+    t: 研究
   - key: options.industry_sector.law
-    t: Law
+    t: 法律
   - key: options.industry_sector.non_profit
-    t: Non-Profit
+    t: 非営利
   - key: options.industry_sector.art
-    t: Art
+    t: アート
   - key: options.industry_sector.crypto
     t: Crypto
   - key: options.industry_sector.aerospace
-    t: Aerospace
+    t: 航空宇宙
   - key: options.industry_sector.web3
     t: Web3
   - key: options.industry_sector.iot
     t: IOT
   - key: options.industry_sector.gambling
-    t: Gambling
+    t: ギャンブル
   - key: options.industry_sector.blockchain
-    t: Blockchain
+    t: ブロックチェーン
   - key: options.industry_sector.design
-    t: Design
+    t: デザイン
   - key: options.industry_sector.unemployed
-    t: Unemployed
+    t: 無職
 
   - key: options.industry_sector.recruiting
     t: Recruiting

--- a/common.yml
+++ b/common.yml
@@ -297,10 +297,10 @@ translations:
     t: 使用状況
 
   - key: sections.finish.title
-    t: Finish Survey
+    t: アンケートを完了
 
   - key: sections.finish.description
-    t: Finish the survey
+    t: アンケートを完了します
 
   ###########################################################################
   # Options

--- a/common.yml
+++ b/common.yml
@@ -353,11 +353,11 @@ translations:
     t: 使ったことがある
 
   # features (no emoji, short versions)
-  - key: options.features.never_heard.short
+  - key: options.features.never_heard.label.short
     t: 知らない
-  - key: options.features.heard.short
+  - key: options.features.heard.label.short
     t: 知っている
-  - key: options.features.used.short
+  - key: options.features.used.label.short
     t: 使った
 
   # patterns
@@ -1209,9 +1209,8 @@ translations:
     t: 使っているもののうち、上のリストに掲載されていないもの
   - key: tools.happiness
     t: 総合的な満足度
-  - key: tools.happiness.description
-    t: >
-      ここに挙げた選択肢について、現在の満足度合いを1（とても不満）から5（とても満足）の間で表すとどれになりますか？
+  - key: tools.happiness.question
+    t: ここに挙げた選択肢について、現在の満足度合いを1（とても不満）から5（とても満足）の間で表すとどれになりますか？
 
   ###########################################################################
   # Demographics (About You/User Info)
@@ -1309,6 +1308,12 @@ translations:
     t: このアンケートを知ったきっかけは？
   - key: user_info.email
     t: メールアドレス
+  - key: user_info.email.description
+    t: >
+      アンケートは現在匿名で記入されています。希望する場合は、メールアドレスを入力して、後で自分の回答にアクセスできるようにし、アンケート結果が公開された際に通知を受けることができます。
+  - key: user_info.email.note
+    t: >
+      私たちは個人データを保存しませんので、メールアドレスを入力いただいた後、それを使用して一意の匿名化されたIDを生成し、その後、メールアドレス自体は私たちの記録から削除します。
   - key: user_info.country
     t: 居住国・居住地
   - key: user_info.country.description

--- a/common.yml
+++ b/common.yml
@@ -27,11 +27,17 @@ translations:
   - key: general.survey_preview
     t: >
       これはプレビュー版です。設問が今後変わる可能性があります。また、回答されたデータはすべて、本アンケートの開始時に削除されます。
+  - key: general.survey_feedback
+    t: Leave feedback
+
   - key: general.survey_read_only_back
     t: >
       <a href="{link}">メインページへ戻る</a>。アンケートへの回答や、回答中のアンケートを再開できます。
   - key: general.take_survey
-    t: "{name}に回答する"
+    t: 回答する
+
+  - key: options.na
+    t: 🚫 該当なし
 
   # surveys
   - key: general.open_surveys
@@ -50,7 +56,15 @@ translations:
     t: アンケートに回答する »
   - key: general.continue_survey
     t: 回答を続ける »
+  - key: general.completion
+    t: "{completion}% 完了"
+  - key: general.started_on
+    t: 開始日時：{createdAt}
+  - key: general.last_modified_on
+    t: 更新日時：{updatedAt}
   - key: general.review_survey
+    t: 回答を確認する »
+  - key: general.review_answers
     t: 回答を確認する »
   - key: general.preview_survey
     t: 回答をプレビュー »
@@ -62,6 +76,8 @@ translations:
     t: 前のセクション
   - key: general.survey_closed
     t: このアンケートは終了しました。
+  - key: general.survey_closed_on
+    t: このアンケートは {endedAt} に終了しました。
   - key: general.survey_results
     t: アンケートの結果を見る »
   - key: general.surveys_available_languages
@@ -76,10 +92,16 @@ translations:
     t: 今回追加された新しい項目
   - key: general.new
     t: New
+  - key: general.devographics_banner
+    t: <a href="https://www.devographics.com/" target="_blank">Devographics</a> is the new name of the collective running the State of JavaScript, CSS, and GraphQL surveys.
 
   # credits
   - key: credits.thanks
     t: スペシャルサンクス
+  - key: credits.contributors
+    t: コントリビュータ
+  - key: credits.contributors.description
+    t: アンケートの作成にご協力いただいた以下の方々に感謝します。
   - key: credits.accessibility
     t: アクセシビリティコンサルティング
   - key: credits.survey_design
@@ -96,6 +118,10 @@ translations:
     t: コードリファクタリング
   - key: credits.data_processing
     t: データ処理
+  - key: credits.back_end_development
+    t: バックエンド開発
+  - key: credits.survey_review
+    t: アンケートのレビュー
 
   # support
   - key: general.support_from
@@ -106,12 +132,15 @@ translations:
     t: プライバシーポリシー
   - key: general.leave_issue
     t: 質問やバグ報告は<a href="{link}" target="_blank">issueを立ててください</a>。
+  - key: general.leave_issue2
+    aliasFor: homepage.leave_issue
   - key: general.emoji_icons
     t: Emoji icons by <a target="_blank" rel="noreferrer" href="https://icons8.com">Icons8</a>
 
   # navigation
   - key: general.table_of_contents
-    t: 目次
+    t: >
+      {sectionCount} セクション ({completion}% 完了)
   - key: general.all_questions_optional
     t: >
       注：すべての質問は任意です。100%にする必要はありません。
@@ -129,6 +158,8 @@ translations:
   # thanks
   - key: general.back
     t: 戻る
+  - key: general.back_to_survey
+    t: アンケートに戻る
   - key: general.thanks
     t: >
       ありがとうございます！
@@ -136,13 +167,31 @@ translations:
       回答が保存されました。アンケート期間が終了するまでは、データの確認や編集を行えます。
 
       ぜひこのアンケートをシェアしてください。みなさん一人一人の回答に価値があります。多くの回答が集まれば、より現実を反映したデータになります。
+  - key: general.thanks1
+    t: >
+      アンケートへのご回答ありがとうございます！回答が保存されました。
+  - key: general.thanks2
+    t: >
+      この調査を共有してくれると助かります！どんな少しの協力も大切ですし、それが私たちのデータをより代表的にする手助けになります。
   - key: thanks.learn_more_about
     t: ほかにも知っておきたい機能はこちら：
   - key: thanks.knowledge_score
     t: ナレッジスコア
-  - key: thanks.score_explanation
+  - key: thanks.features_score
+    t: 機能スコア
+  - key: thanks.quiz_score
+    t: クイズスコア
+  - key: thanks.score_statistics
     t: >
-      あなたはこのアンケートで紹介した全<span class="score-number score-number-total">{total}</span>機能のうち、<span class="score-number score-number-known">{known}</span>を知っている、もしくは使っています。これは全回答者の上位<span class="score-number score-number-ranking">{knowledgeRankingFromTop}%</span>以内に入ります。
+      このアンケートで紹介した全 {total} 機能のうち、あなたは {usage_count} 個を使用し、 {awareness_count} 個聞いたことがあります。これは全回答者の上位{knowledgeRankingFromTop}％に位置しています。おめでとうございます！
+  - key: thanks.score_statistics_noranking
+    t: >
+      このアンケートで紹介した全 {total} 機能のうち、あなたは {usage_count} 個を使用し、 {awareness_count} 個聞いたことがあります。お疲れ様でした！
+  - key: thanks.points
+    t: ポイント
+  - key: thanks.score_awareness_explanation
+    t: >
+      公平性のために、この割合はあなたが知っていると回答した{awareness_total}個の機能に対してのみ計算されます。
   - key: thanks.share_on_twitter
     t: Twitterにシェア
   - key: thanks.share_score_message
@@ -161,8 +210,14 @@ translations:
     t: Select option
   - key: forms.clear_field
     t: Clear question
+  - key: forms.more_options
+    t: Show more…
+  - key: forms.less_options
+    t: Show less
 
-  # partners
+  # partners & sponsors
+  - key: sponsors.with_support_from
+    t: With Special Support From
   - key: sponsors.our_partners
     t: パートナー
   - key: sponsors.become_partner
@@ -181,6 +236,17 @@ translations:
     t: option/altを押して翻訳モードにする。
   - key: general.charts_nivo
     t: チャート生成：<a href="{link}">Nivo</a>。
+  - key: general.made_by_devographics
+    t: Made by <a href="{link}">Devographics</a>
+  - key: general.view_code_example
+    t: コード例を見る
+  - key: general.feature_code_example
+    t: "**{featureName}**のコード例"
+  - key: general.code_example
+    t: コード例
+  - key: general.language_code
+    t: |
+      {language}コード
 
   ###########################################################################
   # Nav
@@ -208,7 +274,7 @@ translations:
   - key: sections.resources.title
     t: リソース
   - key: sections.resources.description
-    t: "{topic}について、どんなリソースを参考にしますか？"
+    t: "どんなリソースを参考にしますか？"
 
   - key: sections.opinions.title
     t: オピニオン
@@ -219,10 +285,32 @@ translations:
     t: そのほかのツール
   - key: sections.other_tools.description
     t: 以下のツールや技術について、あなたが普段から使っているものをチェックしてください。
+  - key: section.tools_others.title
+    aliasFor: section.other_tools.title
+  - key: section.tools_others.description
+    aliasFor: section.other_tools.description
+
+  - key: sections.report.title
+    t: トレンドレポート
+
+  - key: sections.usage.title
+    t: 使用状況
+
+  - key: sections.finish.title
+    t: Finish Survey
+
+  - key: sections.finish.description
+    t: Finish the survey
 
   ###########################################################################
   # Options
   ###########################################################################
+
+  # other answer
+  - key: options.other
+    t: その他
+  - key: options.other.placeholder
+    t: 上記以外であればカンマ（,）区切りで回答してください
 
   # features
   - key: options.features.never_heard
@@ -232,6 +320,30 @@ translations:
   - key: options.features.used
     t: <span aria-hidden="true">👍</span> 使ったことがある
 
+  # features v2
+  - key: options.features2.never_heard
+    t: <span class="option-chip option-main option-main-never_heard">Never heard of it/Not sure what it is</option>
+  - key: options.features2.interested
+    t: |
+      <span class="option-chip option-main option-main-heard">Heard of it</span> » <span class="option-chip option-positive">Interested</span>
+  - key: options.features2.not_interested
+    t: |
+      <span class="option-chip option-main option-main-heard">Heard of it</span> » <span class="option-chip option-negative">Not interested</span>
+  - key: options.features2.used_positive
+    t: |
+      <span class="option-chip option-main option-main-used">Used it</span> » <span class="option-chip option-positive">Positive experience</span>
+  - key: options.features2.used_negative
+    t: |
+      <span class="option-chip option-main option-main-used">Used it</span> » <span class="option-chip option-negative">Negative experience</span>
+
+  # features (short)
+  - key: options.features.never_heard.short
+    t: <span aria-hidden="true">🤷</span> 知らない
+  - key: options.features.heard.short
+    t: <span aria-hidden="true">👀</span> 知っている
+  - key: options.features.used.short
+    t: <span aria-hidden="true">🤓</span> 使ったことがある
+
   # features (no emoji)
   - key: options.features.never_heard.label
     t: 知らない / 何なのかわからない
@@ -240,7 +352,7 @@ translations:
   - key: options.features.used.label
     t: 使ったことがある
 
-  # features (short versions)
+  # features (no emoji, short versions)
   - key: options.features.never_heard.short
     t: 知らない
   - key: options.features.heard.short
@@ -398,6 +510,8 @@ translations:
     t: ">20年"
 
   # company size
+  - key: options.company_size.na
+    t: 🚫 該当なし
   - key: options.company_size.range_1
     t: 1人
   - key: options.company_size.range_1_5
@@ -416,6 +530,8 @@ translations:
     t: 1000人より多い
 
   # company size (short versions)
+  - key: options.company_size.na.short
+    t: N/A
   - key: options.company_size.range_1.short
     t: 1
   - key: options.company_size.range_1_5.short
@@ -434,6 +550,8 @@ translations:
     t: ">1000"
 
   # salary
+  - key: options.yearly_salary.na
+    t: 🚫 該当なし
   - key: options.yearly_salary.range_work_for_free
     t: 収入なし
   - key: options.yearly_salary.range_0_10
@@ -449,7 +567,24 @@ translations:
   - key: options.yearly_salary.range_more_than_200
     t: $200,000以上
 
+  - key: options.yearly_salary.range_0_20
+    t: $0～$20,000
+  - key: options.yearly_salary.range_20_40
+    t: $20,000～$40,000
+  - key: options.yearly_salary.range_40_60
+    t: $40,000～$60,000
+  - key: options.yearly_salary.range_60_80
+    t: $60,000～$80,000
+  - key: options.yearly_salary.range_80_100
+    t: $80,000～$100,000
+  - key: options.yearly_salary.range_100_150
+    t: $100,000～$150,000
+  - key: options.yearly_salary.range_150_200
+    t: $150,000～$200,000
+
   # salary (short versions)
+  - key: options.yearly_salary.na.short
+    t: N/A
   - key: options.yearly_salary.range_work_for_free.short
     t: $0
   - key: options.yearly_salary.range_0_10.short
@@ -586,6 +721,19 @@ translations:
   - key: options.race_ethnicity.not_listed
     t: この中にはない
 
+  - key: options.race_ethnicity.european
+    t: ヨーロピアン
+  - key: options.race_ethnicity.indian
+    t: インディアン
+  - key: options.race_ethnicity.human
+    t: ヒューマン
+  - key: options.race_ethnicity.slav
+    t: スラブ
+  - key: options.race_ethnicity.north_african
+    t: 北アフリカ
+  - key: options.race_ethnicity.jewish
+    t: ユダヤ
+
   # Race & Ethnicity (short)
 
   - key: options.race_ethnicity.white_european.short
@@ -612,6 +760,8 @@ translations:
     t: この中にはない
 
   # Disability Status
+  - key: options.disability_status.na
+    t: 🚫 該当なし
   - key: options.disability_status.visual_impairments
     t: >
       視覚障害（全盲、色覚異常など）
@@ -698,6 +848,8 @@ translations:
     t: コンサルティング・サービス業
   - key: options.industry_sector.travel
     t: 旅行
+  - key: options.industry_sector.tourism
+    t: 観光
   - key: options.industry_sector.insurance
     t: 保険
   - key: options.industry_sector.logistics
@@ -722,6 +874,50 @@ translations:
     t: 運輸
   - key: options.industry_sector.manufacturing
     t: 製造
+
+  - key: options.industry_sector.tech_it
+    t: Tech & IT
+  - key: options.industry_sector.human_resources
+    t: Human Resources
+  - key: options.industry_sector.sports
+    t: Sports
+  - key: options.industry_sector.gaming
+    t: Gaming
+  - key: options.industry_sector.research
+    t: Research
+  - key: options.industry_sector.law
+    t: Law
+  - key: options.industry_sector.non_profit
+    t: Non-Profit
+  - key: options.industry_sector.art
+    t: Art
+  - key: options.industry_sector.crypto
+    t: Crypto
+  - key: options.industry_sector.aerospace
+    t: Aerospace
+  - key: options.industry_sector.web3
+    t: Web3
+  - key: options.industry_sector.iot
+    t: IOT
+  - key: options.industry_sector.gambling
+    t: Gambling
+  - key: options.industry_sector.blockchain
+    t: Blockchain
+  - key: options.industry_sector.design
+    t: Design
+  - key: options.industry_sector.unemployed
+    t: Unemployed
+
+  - key: options.industry_sector.recruiting
+    t: Recruiting
+  - key: options.industry_sector.agency
+    t: Agency
+  - key: options.industry_sector.business
+    t: Business
+  - key: options.industry_sector.communication
+    t: Comunication
+  - key: options.industry_sector.security
+    t: Security
 
   # tool evaluation
   - key: options.tool_evaluation.learning_curve_documentation
@@ -778,6 +974,8 @@ translations:
     t: ARIA属性
 
   # learning methods
+  - key: options.first_steps.na
+    t: 🚫 該当なし
   - key: options.first_steps.books
     t: 書籍
   - key: options.first_steps.videos
@@ -799,6 +997,65 @@ translations:
   - key: options.first_steps.mentoring
     t: メンタリング
 
+  - key: options.first_steps.documentation
+    t: ドキュメント
+  - key: options.first_steps.blogs
+    t: ブログ
+  - key: options.first_steps.view_source
+    t: ソースコードを見る
+  - key: options.first_steps.trial_and_error
+    t: トライ＆エラー
+  - key: options.first_steps.forums
+    t: フォーラム
+  - key: options.first_steps.newsletters
+    t: ニュースレター
+  - key: options.first_steps.events
+    t: イベント
+
+  # learning methods
+
+  - key: resources.learning_methods
+    t: Learning Methods
+
+  - key: options.learning_methods.na
+    aliasFor: options.first_steps.na
+  - key: options.learning_methods.books
+    aliasFor: options.first_steps.books
+  - key: options.learning_methods.videos
+    aliasFor: options.first_steps.videos
+  - key: options.learning_methods.school
+    aliasFor: options.first_steps.school
+  - key: options.learning_methods.courses_free
+    aliasFor: options.first_steps.courses_free
+  - key: options.learning_methods.courses_paid
+    aliasFor: options.first_steps.courses_paid
+  - key: options.learning_methods.podcasts
+    aliasFor: options.first_steps.podcasts
+  - key: options.learning_methods.bootcamp
+    aliasFor: options.first_steps.bootcamp
+  - key: options.learning_methods.on_the_job
+    aliasFor: options.first_steps.on_the_job
+  - key: options.learning_methods.self_directed
+    aliasFor: options.first_steps.self_directed
+  - key: options.learning_methods.mentoring
+    aliasFor: options.first_steps.mentoring
+  - key: options.learning_methods.documentation
+    aliasFor: options.first_steps.documentation
+  - key: options.learning_methods.blogs
+    aliasFor: options.first_steps.blogs
+  - key: options.learning_methods.view_source
+    aliasFor: options.first_steps.view_source
+  - key: options.learning_methods.documentation
+    aliasFor: options.first_steps.documentation
+  - key: options.learning_methods.trial_and_error
+    aliasFor: options.first_steps.trial_and_error
+  - key: options.learning_methods.forums
+    aliasFor: options.first_steps.forums
+  - key: options.learning_methods.newsletters
+    aliasFor: options.first_steps.newsletters
+  - key: options.learning_methods.events
+    aliasFor: options.first_steps.events
+
   # degree
   - key: options.higher_education_degree.no_degree
     t: 学位なし
@@ -815,6 +1072,22 @@ translations:
   - key: options.higher_education_degree.yes_unrelated.short
     t: 学位あり（関係なし）
 
+  # employment_status
+  - key: options.employment_status.full_time
+    t: フルタイム
+  - key: options.employment_status.student
+    t: 学生
+  - key: options.employment_status.self_employed
+    t: 自営業
+  - key: options.employment_status.contractor
+    t: 請負
+  - key: options.employment_status.part_time
+    t: パートタイム
+  - key: options.employment_status.between_jobs
+    t: 休職中
+  - key: options.employment_status.retired
+    t: 退職済み
+
   # bracket
   - key: options.bracket.round1
     t: ラウンド1勝者
@@ -824,6 +1097,107 @@ translations:
     t: ラウンド3勝者
   - key: options.bracket.combined
     t: Combined
+
+  # email_temporary (receive updates?)
+  - key: options.receive_notifications.yes
+    t: はい、アンケートの結果が公開された際にメールでお知らせください。
+
+  # usage type
+
+  - key: usage.usage_type
+    t: Usage Type
+
+  - key: options.usage_type.professionally
+    t: プロフェッショナルとして
+  - key: options.usage_type.student
+    t: 学生として
+  - key: options.usage_type.hobby
+    t: 趣味として
+
+  - key: options.percentage_segments.range_0_10
+    t: 0-10%
+  - key: options.percentage_segments.range_11_20
+    t: 11-20%
+  - key: options.percentage_segments.range_21_30
+    t: 21-30%
+  - key: options.percentage_segments.range_31_40
+    t: 31-40%
+  - key: options.percentage_segments.range_41_50
+    t: 41-50%
+  - key: options.percentage_segments.range_51_60
+    t: 51-60%
+  - key: options.percentage_segments.range_61_70
+    t: 61-70%
+  - key: options.percentage_segments.range_71_80
+    t: 71-80%
+  - key: options.percentage_segments.range_81_90
+    t: 81-90%
+  - key: options.percentage_segments.range_91_100
+    t: 91-100%
+
+  - key: options.completion_stats.range_0_10
+    aliasFor: options.percentage_segments.range_0_10
+  - key: options.completion_stats.range_11_20
+    aliasFor: options.percentage_segments.range_11_20
+  - key: options.completion_stats.range_21_30
+    aliasFor: options.percentage_segments.range_21_30
+  - key: options.completion_stats.range_31_40
+    aliasFor: options.percentage_segments.range_31_40
+  - key: options.completion_stats.range_41_50
+    aliasFor: options.percentage_segments.range_41_50
+  - key: options.completion_stats.range_51_60
+    aliasFor: options.percentage_segments.range_51_60
+  - key: options.completion_stats.range_61_70
+    aliasFor: options.percentage_segments.range_61_70
+  - key: options.completion_stats.range_71_80
+    aliasFor: options.percentage_segments.range_71_80
+  - key: options.completion_stats.range_81_90
+    aliasFor: options.percentage_segments.range_81_90
+  - key: options.completion_stats.range_91_100
+    aliasFor: options.percentage_segments.range_91_100
+
+  - key: options.knowledge_score.range_0_10
+    aliasFor: options.percentage_segments.range_0_10
+  - key: options.knowledge_score.range_11_20
+    aliasFor: options.percentage_segments.range_11_20
+  - key: options.knowledge_score.range_21_30
+    aliasFor: options.percentage_segments.range_21_30
+  - key: options.knowledge_score.range_31_40
+    aliasFor: options.percentage_segments.range_31_40
+  - key: options.knowledge_score.range_41_50
+    aliasFor: options.percentage_segments.range_41_50
+  - key: options.knowledge_score.range_51_60
+    aliasFor: options.percentage_segments.range_51_60
+  - key: options.knowledge_score.range_61_70
+    aliasFor: options.percentage_segments.range_61_70
+  - key: options.knowledge_score.range_71_80
+    aliasFor: options.percentage_segments.range_71_80
+  - key: options.knowledge_score.range_81_90
+    aliasFor: options.percentage_segments.range_81_90
+  - key: options.knowledge_score.range_91_100
+    aliasFor: options.percentage_segments.range_91_100
+
+  # source
+  - key: options.source.angular_community
+    t: Angularコミュニティ
+  - key: options.source.work
+    t: Workplace
+  - key: options.source.word_of_mouth
+    t: 口コミ
+  - key: options.source.podcast
+    t: ポッドキャスト
+  - key: options.source.other_online_sources
+    t: その他のオンラインリソース
+  - key: options.source.blog
+    t: ブログ
+  # - key: options.source.
+  #   t:
+  # - key: options.source.
+  #   t:
+  # - key: options.source.
+  #   t:
+  # - key: options.source.
+  #   t:
 
   ###########################################################################
   # Tools
@@ -901,7 +1275,7 @@ translations:
     t: >
       多様性に関する情報収集と公開がセンシティブな問題になりうることは承知しています。その上で、このアンケートの包括性や代表性を知り、また向上させるためにデータを収集することが重要と考えています。
 
-  # skin tone/appearance
+  # race & ethnicity
   - key: user_info.race_ethnicity
     t: 人種・民族
   - key: user_info.race_ethnicity.description
@@ -910,6 +1284,13 @@ translations:
   - key: user_info.race_ethnicity.note
     t: >
       多様性に関する情報収集と公開がセンシティブな問題になりうることは承知しています。その上で、このアンケートの包括性や代表性を知り、また向上させるためにデータを収集することが重要と考えています。
+  - key: user_info.race_ethnicity.not_allowed
+    t: >
+      地域のポリシーに準拠するため、あなたの国、または地域での人種または民族データの収集は無効になっています。
+  - key: user_info.race_ethnicity.others
+    t: そのほかの人種・民族
+  - key: user_info.race_ethnicity_freeform
+    aliasFor: user_info.race_ethnicity.others
 
   # disability status
   - key: user_info.disability_status
@@ -932,6 +1313,10 @@ translations:
     t: 居住国・居住地
   - key: user_info.country.description
     t: 住んでいる国はどこですか？
+  - key: user_info.country
+    t: 国または地域
+  - key: user_info.country.description
+    t: いま住んでいる国はどこですか？
 
   - key: user_info.github_username
     t: GitHubのユーザー名
@@ -954,11 +1339,45 @@ translations:
   - key: user_info.industry_sector.others.description
     t: 上記のリストにない場合は、書いてください。
 
+  - key: usage.industry_sector
+    aliasFor: user_info.industry_sector
+  - key: usage.industry_sector.description
+    aliasFor: user_info.industry_sector.description
+  - key: usage.industry_sector.others
+    aliasFor: user_info.industry_sector.others
+  - key: usage.industry_sector_freeform
+    aliasFor: user_info.industry_sector.others
+  - key: usage.industry_sector.others.description
+    aliasFor: user_info.industry_sector.description
+
   # degree
   - key: user_info.higher_education_degree
     t: 高等教育の学位
   - key: user_info.higher_education_degree.description
     t: 高等教育を受け、学位を持っていますか？
+
+  # employment status
+  - key: user_info.employment_status
+    t: 雇用状況
+  - key: user_info.employment_status.description
+    t: あなたの雇用状況は？
+
+  # completion
+  - key: user_info.completion_stats
+    t: アンケート完了状況
+  - key: user_info.completion_stats.description
+    t: アンケートにどのくらい回答しましたか？
+
+  # email_temporary (receive updates?)
+  - key: user_info.receive_notifications
+    t: アンケート結果が公開されたときに通知を受け取りますか？
+  - key: user_info.receive_notifications.note
+    t: >
+      私たちは個人データを保存しませんので、あなたのメールアドレスがメーリングリストプロバイダに送信された後、それは私たちの記録からは削除されます。
+
+  # how can we improve the survey?
+  - key: user_info.how_can_we_improve
+    t: このアンケートについて改善できそうなところはありますか？
 
   ###########################################################################
   # Other Tools
@@ -1049,6 +1468,11 @@ translations:
     t: そのほかのブログ・マガジン
   - key: resources.blogs_news_magazines.others.description
     t: そのほかの回答（自由入力欄）。
+  - key: options.blogs_news_magazines.na
+    t: 🚫 該当なし
+  - key: resources.blogs_news_magazines.placeholder
+    t: |
+      ブログ/ニュースレター #{index}…
 
   # sites & courses
   - key: resources.sites_courses
@@ -1059,6 +1483,22 @@ translations:
     t: そのほかのウェブサイト・学習コース
   - key: resources.sites_courses.others.description
     t: そのほかの回答（自由入力欄）。
+  - key: options.sites_courses.na
+    t: 🚫 該当なし
+  - key: resources.sites_courses.placeholder
+    t: |
+      ウェブサイト/学習コース #{index}…
+
+  # paid courses
+  - key: resources.paid_courses
+    t: 有料コース
+  - key: resources.paid_courses.question
+    t: JavaScriptを学ぶために使用した有料のリソース（コース、動画、書籍など）はありますか？
+  - key: options.paid_courses.na
+    t: 🚫 該当なし
+  - key: resources.paid_courses.placeholder
+    t: |
+      コース/書籍 #{index}…
 
   # podcasts
   - key: resources.podcasts
@@ -1069,11 +1509,16 @@ translations:
     t: そのほかのポッドキャスト
   - key: resources.podcasts.others.description
     t: そのほかの回答（自由入力欄）。
+  - key: options.podcasts.na
+    t: 🚫 該当なし
+  - key: resources.podcasts.placeholder
+    t: |
+      ポッドキャスト #{index}…
 
   # people
   - key: resources.people
     t: 人物
-  - key: resources.people.description
+  - key: resources.people.question
     t: ブログや書籍を読んでいたり、フォローしている人。または単におすすめしたい人。
   # - key: resources.people.others
   #   t: Other People
@@ -1084,3 +1529,95 @@ translations:
   - key: resources.people.others.description
     t: >
       ブログや書籍を読んでいたり、フォローしている人。または単におすすめしたい人（複数いる場合はカンマで区切ってください）。
+  - key: options.people.na
+    t: 🚫 該当なし
+  - key: resources.people.placeholder
+    t: |
+      人物 #{index}…
+
+  # other surveys
+  - key: resources.other_surveys
+    t: その他のアンケート
+  - key: resources.other_surveys.question
+    t: 他に参加している開発者向けアンケートはありますか？
+  - key: resources.other_surveys.others
+    t: 上記で挙げた以外の調査には参加していますか？
+  - key: options.other_surveys.na
+    t: 🚫 該当なし
+    # TODO: temporary fix, this should not be needed in the first place
+  - key: user_info.other_surveys.question
+    t: 他の参加している開発者向けアンケートはありますか？
+
+  - key: user_info.other_surveys
+    aliasFor: resources.other_surveys
+  - key: user_info.other_surveys.question
+    aliasFor: resources.other_surveys.question
+
+  # video creators
+  - key: resources.video_creators
+    t: 動画配信者
+  - key: resources.video_creators.question
+    t: プログラミング関連の動画配信者をフォローしていますか？（YouTube、Twitchなど）
+  - key: resources.video_creators.others
+    t: その他の動画配信者
+  - key: options.video_creators.na
+    t: 🚫 該当なし
+  - key: resources.video_creators.placeholder
+    t: |
+      動画配信者 #{index}…
+
+  ###########################################################################
+  # Follow-Up Questions
+  ###########################################################################
+
+  - key: followups.button
+    t: Tell us more…
+
+  - key: followups.description
+    t: |
+      Optionally, you can tell us more about why you picked this answer:
+
+  - key: followups.description.short
+    t: |
+      Tell us more:
+
+  - key: followups.placeholder
+    t: Other reason…
+
+  - key: followups.want_to_learn_more
+    t: 学んでみたい
+  - key: followups.not_interested
+    t: 興味がない
+  - key: followups.insufficient_browser_support
+    t: 不十分なブラウザサポート
+  - key: followups.not_needed
+    t: 必要ない
+  - key: followups.hard_to_use
+    t: 使うのが困難
+  - key: followups.positive_experience
+    t: 使ってよかった
+  - key: followups.not_powerful
+    t: 十分ではない
+
+  - key: followups.sentiment_interested
+    t: 興味がある
+  - key: followups.sentiment_not_interested
+    t: 興味がない
+  - key: followups.sentiment_positive_experience
+    t: また使いたい
+  - key: followups.sentiment_negative_experience
+    t: 使いたくない
+
+  # - key: followups.
+  #   t:
+  # - key: followups.
+  #   t:
+  # - key: followups.
+  #   t:
+  # - key: followups.
+  #   t:
+
+  # entities info
+
+  - key: entity.learn_more
+    t: Learn more…

--- a/common.yml
+++ b/common.yml
@@ -322,19 +322,19 @@ translations:
 
   # features v2
   - key: options.features2.never_heard
-    t: <span class="option-chip option-main option-main-never_heard">Never heard of it/Not sure what it is</option>
+    t: <span class="option-chip option-main option-main-never_heard">知らない / 何なのかわからない</option>
   - key: options.features2.interested
     t: |
-      <span class="option-chip option-main option-main-heard">Heard of it</span> » <span class="option-chip option-positive">Interested</span>
+      <span class="option-chip option-main option-main-heard">知っている</span> » <span class="option-chip option-positive">興味がある</span>
   - key: options.features2.not_interested
     t: |
-      <span class="option-chip option-main option-main-heard">Heard of it</span> » <span class="option-chip option-negative">Not interested</span>
+      <span class="option-chip option-main option-main-heard">知っている</span> » <span class="option-chip option-negative">興味はない</span>
   - key: options.features2.used_positive
     t: |
-      <span class="option-chip option-main option-main-used">Used it</span> » <span class="option-chip option-positive">Positive experience</span>
+      <span class="option-chip option-main option-main-used">使ったことがある</span> » <span class="option-chip option-positive">良い体験だった</span>
   - key: options.features2.used_negative
     t: |
-      <span class="option-chip option-main option-main-used">Used it</span> » <span class="option-chip option-negative">Negative experience</span>
+      <span class="option-chip option-main option-main-used">使ったことがある</span> » <span class="option-chip option-negative">良くない体験だった</span>
 
   # features (short)
   - key: options.features.never_heard.short

--- a/common.yml
+++ b/common.yml
@@ -1181,7 +1181,7 @@ translations:
   - key: options.source.angular_community
     t: Angularコミュニティ
   - key: options.source.work
-    t: Workplace
+    t: 職場
   - key: options.source.word_of_mouth
     t: 口コミ
   - key: options.source.podcast

--- a/common.yml
+++ b/common.yml
@@ -28,7 +28,7 @@ translations:
     t: >
       これはプレビュー版です。設問が今後変わる可能性があります。また、回答されたデータはすべて、本アンケートの開始時に削除されます。
   - key: general.survey_feedback
-    t: Leave feedback
+    t: フィードバックを送る
 
   - key: general.survey_read_only_back
     t: >

--- a/common.yml
+++ b/common.yml
@@ -93,7 +93,7 @@ translations:
   - key: general.new
     t: New
   - key: general.devographics_banner
-    t: <a href="https://www.devographics.com/" target="_blank">Devographics</a> is the new name of the collective running the State of JavaScript, CSS, and GraphQL surveys.
+    t: <a href="https://www.devographics.com/" target="_blank">Devographics</a>はState of JavaScript, CSS, GraphQLを運営している運営の新しい名前です。
 
   # credits
   - key: credits.thanks

--- a/common.yml
+++ b/common.yml
@@ -728,11 +728,11 @@ translations:
   - key: options.race_ethnicity.human
     t: ヒューマン
   - key: options.race_ethnicity.slav
-    t: スラブ
+    t: スラブ系
   - key: options.race_ethnicity.north_african
-    t: 北アフリカ
+    t: 北アフリカ系
   - key: options.race_ethnicity.jewish
-    t: ユダヤ
+    t: ユダヤ系
 
   # Race & Ethnicity (short)
 
@@ -1084,9 +1084,9 @@ translations:
   - key: options.employment_status.part_time
     t: パートタイム
   - key: options.employment_status.between_jobs
-    t: 休職中
+    t: 失業中/求職中
   - key: options.employment_status.retired
-    t: 退職済み
+    t: リタイア
 
   # bracket
   - key: options.bracket.round1

--- a/common.yml
+++ b/common.yml
@@ -726,7 +726,7 @@ translations:
   - key: options.race_ethnicity.indian
     t: インド系
   - key: options.race_ethnicity.human
-    t: human
+    t: 人類
   - key: options.race_ethnicity.slav
     t: スラブ系
   - key: options.race_ethnicity.north_african

--- a/common.yml
+++ b/common.yml
@@ -722,11 +722,11 @@ translations:
     t: この中にはない
 
   - key: options.race_ethnicity.european
-    t: ヨーロピアン
+    t: ヨーロッパ系
   - key: options.race_ethnicity.indian
-    t: インディアン
+    t: インド系
   - key: options.race_ethnicity.human
-    t: ヒューマン
+    t: human
   - key: options.race_ethnicity.slav
     t: スラブ系
   - key: options.race_ethnicity.north_african

--- a/state_of_js.yml
+++ b/state_of_js.yml
@@ -1,392 +1,1135 @@
 locale: ja-JP
 namespace: js
 translations:
-    ###########################################################################
-    # General
-    ###########################################################################
+  ###########################################################################
+  # General
+  ###########################################################################
 
-    - key: general.state_of_js.intro
-      t: >
-          JavaScriptまわりは、もう少し情報が整理されているとよさそうです。
-
-
-          このアンケートは2016年から、20000人以上の開発者に対し、現在やこれからのトレンドについてデータを集めてきました。
+  - key: general.state_of_js.intro
+    t: >
+      JavaScriptまわりは、もう少し情報が整理されているとよさそうです。
 
 
-          開発者が次はどのライブラリを学びたいか、またはどのライブラリが最も満足度が高いかなどを知るために、このアンケートへの回答にご協力ください。
-
-    ###########################################################################
-    # Sections
-    ###########################################################################
-
-    - key: sections.syntax.title
-      t: 構文
-    - key: sections.syntax.description
-      t: JavaScriptの文法
-
-    - key: sections.language.title
-      t: 言語
-    - key: sections.language.description
-      t: JavaScriptの語彙
-
-    - key: sections.data_structures.title
-      t: データ構造
-    - key: sections.data_structures.description
-      t: データの保持と変更のやりかた
-
-    - key: sections.browser_apis.title
-      t: ブラウザのAPI
-    - key: sections.browser_apis.description
-      t: ブラウザが提供する機能
-
-    - key: sections.other_features.title
-      t: そのほかの機能
-    - key: sections.other_features.description
-      t: ほかの技術やパターン
-
-    - key: sections.patterns.title
-      t: パターン
-    - key: sections.patterns.description
-      t: どんな風にコードを書くか
-
-    - key: sections.javascript_flavors.title
-      t: JavaScriptフレーバー
-    - key: sections.javascript_flavors.description
-      t: JavaScriptにコンパイルされる言語
-
-    - key: sections.front_end_frameworks.title
-      t: フロントエンドフレームワーク
-    - key: sections.front_end_frameworks.description
-      t: フロントエンドのフレームワークやライブラリ
-
-    - key: sections.datalayer.title
-      t: データ層
-    - key: sections.datalayer.description
-      t: アプリでのデータの読み込みや管理
-
-    - key: sections.back_end_frameworks.title
-      t: バックエンドフレームワーク
-    - key: sections.back_end_frameworks.description
-      t: サーバーでのJavaScript
-
-    - key: sections.testing.title
-      t: テスト
-    - key: sections.testing.description
-      t: コードのテストに使うツール
-
-    - key: sections.mobile_desktop.title
-      t: モバイル＆デスクトップ
-    - key: sections.mobile_desktop.description
-      t: モバイルやデスクトップアプリでのJavaScript
-
-    - key: sections.build_tools.title
-      t: ビルドツール
-    - key: sections.build_tools.description
-      t: コードのコンパイルとビルド
-
-    - key: sections.monorepo_tools.title
-      t: モノレポのツール
-    - key: sections.monorepo_tools.description
-      t: JavaScriptモノレポの管理に使うツール
-
-    - key: sections.tools_others.title
-      t: そのほかのツール
-    - key: sections.tools_others.description
-      t: そのほかのJavaScriptツール
-
-    - key: sections.other_tools.title
-      t: そのほかのツール
-    - key: sections.other_tools.description
-      t: 以下のツールや技術について、普段使っているものにチェックをつけてください
-
-    ###########################################################################
-    # Options
-    ###########################################################################
-
-    # JS pain points
-    # - key: options.js_pain_points.browser_interoperability
-    #   t: Browser Compatibility
-    # - key: options.js_pain_points.browser_interoperability.description
-    #   t: Differences between Chrome, Safari, Firefox, etc.
-    # - key: options.js_pain_points.animations
-    #   t: Animations
-    # - key: options.js_pain_points.animations.description
-    #   t: Managing animations, transitions, etc. using JavaScript.
-    # - key: options.js_pain_points.form_handling
-    #   t: Form Handling
-    # - key: options.js_pain_points.form_handling.description
-    #   t: Creating forms, managing their state and errors, and saving their data. 
-    - key: options.js_pain_points.state_management
-      t: ステート管理
-    - key: options.js_pain_points.state_management.description
-      t: 複雑なアプリケーションで、グローバルなデータのステートを管理すること。
-    # - key: options.js_pain_points.performance_issues
-    #   t: Performance Issues
-    # - key: options.js_pain_points.performance_issues.description
-    #   t: Bundle sizes, slow loading, and other performance issues. 
-    - key: options.js_pain_points.managing_dependencies
-      t: 依存関係の管理
-    - key: options.js_pain_points.managing_dependencies.description
-      t: 依存関係やパッケージのバージョン、バンドルサイズを管理すること。
-    - key: options.js_pain_points.architecture
-      t: コード設計
-    - key: options.js_pain_points.architecture.description
-      t: コードベースを構造化したり管理すること。
-    - key: options.js_pain_points.finding_packages
-      t: パッケージの検索
-    - key: options.js_pain_points.finding_packages.description
-      t: JavaScriptパッケージを探したり評価すること。
-    - key: options.js_pain_points.writing_modules
-      t: モジュールの作成
-    - key: options.js_pain_points.writing_modules.description
-      t: JavaScriptモジュールを作成したり、パッケージとして公開すること。
-    - key: options.js_pain_points.debugging
-      t: デバッグ
-    - key: options.js_pain_points.debugging.description
-      t: コードの問題点を見つけたり、解決すること。
-    - key: options.js_pain_points.async_code
-      t: 非同期処理
-    - key: options.js_pain_points.async_code.description
-      t: 非同期な関数を処理すること。
-    - key: options.js_pain_points.modules_management
-      t: モジュール管理
-    - key: options.js_pain_points.modules_management.description
-      t: モジュールを書いたり読み込んだりすること。
-    - key: options.js_pain_points.date_management
-      t: 日付や時刻の処理
-    - key: options.js_pain_points.date_management.description
-      t: 日付や時刻を処理したり操作すること。
-    # - key: options.js_pain_points.xxx
-    #   t: 
-    # - key: options.js_pain_points.xxx.description
-    #   t: 
+      このアンケートは2016年から、20000人以上の開発者に対し、現在やこれからのトレンドについてデータを集めてきました。
 
 
-    # JS missing features
-    - key: options.currently_missing_from_js.static_typing
-      t: 静的型付け
-    - key: options.currently_missing_from_js.static_typing.description
-      t: 型のネイティブサポート（TypeScriptと同様の機能）。
-    - key: options.currently_missing_from_js.standard_library
-      t: 標準ライブラリ
-    - key: options.currently_missing_from_js.standard_library.description
-      t: 共通ユーティリティの標準ライブラリ。
-    - key: options.currently_missing_from_js.pattern_matching
-      t: パターンマッチ
-    - key: options.currently_missing_from_js.pattern_matching.description
-      t: オブジェクトのパターンマッチに使う新しい`match`キーワード。
-    - key: options.currently_missing_from_js.pipe_operator
-      t: パイプ演算子
-    - key: options.currently_missing_from_js.pipe_operator.description
-      t: 関数の結果を別の関数に渡す新しい`|>`演算子。
-    - key: options.currently_missing_from_js.decorators
-      t: デコレータ
-    - key: options.currently_missing_from_js.decorators.description
-      t: メタプログラミングや値に処理を付加するデコレータ。
-    - key: options.currently_missing_from_js.immutable_data_structures
-      t: イミュータブルなデータ構造
-    - key: options.currently_missing_from_js.immutable_data_structures.description
-      t: '`Record`や`Tuple`など、より徹底したイミュータブルなデータ構造。'
-    - key: options.currently_missing_from_js.better_date_management
-      t: より良い日付管理
-    - key: options.currently_missing_from_js.better_date_management.description
-      t: 日付や時刻を処理するための新しい`Temporal`オブジェクト。
-    - key: options.currently_missing_from_js.observable
-      t: Observable
-    - key: options.currently_missing_from_js.observable.description
-      t: プッシュベースなデータソースのモデリングに使う新しい型`Observable`。
-    # - key: options.currently_missing_from_js.xxx
-    #   t: 
-    # - key: options.currently_missing_from_js.xxx.description
-    #   t: 
+      開発者が次はどのライブラリを学びたいか、またはどのライブラリが最も満足度が高いかなどを知るために、このアンケートへの回答にご協力ください。
 
+  - key: general.state_of_js.title
+    t: The State of JavaScript Developer Survey
 
-    ###########################################################################
-    # Features
-    ###########################################################################
+  - key: general.state_of_js.description
+    t: The annual developer survey of the JavaScript ecosystem
 
-    # syntax
-    - key: features.destructuring
-      t: 分割代入（destructuring）
-    - key: features.spread_operator
-      t: スプレッド構文
-    - key: features.arrow_functions
-      t: アロー関数（arrow functions）
-    - key: features.nullish_coalescing
-      t: Nullish Coalescing
-    - key: features.optional_chaining
-      t: Optional Chaining
-    - key: features.private_fields
-      t: プライベートフィールド
+  ###########################################################################
+  # Sections
+  ###########################################################################
 
-    # language
-    - key: features.proxies
-      t: Proxy
-    - key: features.async_await
-      t: Async/Await
-    - key: features.promises
-      t: Promise
-    - key: features.decorators
-      t: デコレータ
-    - key: features.decorators.description
-      t: デコレータを簡単に言うと、コードの一部を別のコードでラップする（文字通り「デコレート」する）仕組みです。
-    - key: features.dynamic_import
-      t: Dynamic Import
+  - key: sections.features.title
+    t: Features
+  - key: sections.features.description
+    t: Syntax, browser APIs, and other features.
 
-    # other features
-    - key: features.pwa
-      t: プログレッシブ・ウェブアプリ（PWA）
-    - key: features.wasm
-      t: WebAssembly (WASM)
+  - key: sections.syntax.title
+    t: 構文
+  - key: sections.syntax.description
+    t: JavaScriptの文法
 
-    # patterns
-    - key: patterns.object_oriented_programming
-      t: オブジェクト指向プログラミング
-    - key: features.functional_programming
-      t: 関数型プログラミング
-    - key: features.reactive_programming
-      t: リアクティブプログラミング
+  - key: sections.language.title
+    t: 言語
+  - key: sections.language.description
+    t: JavaScriptの語彙
 
-    # upcoming features
-    # - key: features.static_typing
-    #   t: Static Typing
+  - key: sections.data_structures.title
+    t: データ構造
+  - key: sections.data_structures.description
+    t: データの保持と変更のやりかた
 
-    # - key: features.standard_library
-    #   t: Standard Library
+  - key: sections.browser_apis.title
+    t: ブラウザのAPI
+  - key: sections.browser_apis.description
+    t: ブラウザが提供する機能
 
-    # - key: features.pattern_matching
-    #   t: Pattern Matching
+  - key: sections.other_features.title
+    t: そのほかの機能
+  - key: sections.other_features.description
+    t: ほかの技術やパターン
 
-    # - key: features.pipe_operator
-    #   t: Pipe Operator
+  - key: sections.patterns.title
+    t: パターン
+  - key: sections.patterns.description
+    t: どんな風にコードを書くか
 
-    # - key: features.immutable_data_structures
-    #   t: Immutable Data Structures
+  - key: sections.javascript_flavors.title
+    t: JavaScriptフレーバー
+  - key: sections.javascript_flavors.description
+    t: JavaScriptにコンパイルされる言語
 
-    ###########################################################################
-    # Tools
-    ###########################################################################
+  - key: sections.front_end_frameworks.title
+    t: フロントエンドフレームワーク
+  - key: sections.front_end_frameworks.description
+    t: フロントエンドのフレームワークやライブラリ
 
-    - key: tools.angular.description
-      t: これは[Angular](https://angular.io/)についてで、非推奨になった[AngularJS](https://angularjs.org/)のものではないことに注意してください。
-   
-    ###########################################################################
-    # Other Tools
-    ###########################################################################
+  - key: sections.datalayer.title
+    t: データ層
+  - key: sections.datalayer.description
+    t: アプリでのデータの読み込みや管理
 
-    - key: tools_others.runtimes
-      t: JavaScriptランタイム
-    - key: tools_others.runtimes.description
-      t: いつもどのエンジン・ランタイム・実行環境を使っていますか？
-    - key: tools_others.runtimes.others
-      t: そのほかのランタイム
-    - key: tools_others.runtimes.others.description
-      t: そのほかの回答（自由入力欄）
+  - key: sections.rendering_frameworks.title
+    t: Rendering Frameworks
+  - key: sections.rendering_frameworks.description
+    t: Frameworks focused on rendering and serving your application
 
-    - key: tools_others.package_registries
-      t: パッケージレジストリ
-    - key: tools_others.package_registries.description
-      t: いつもどのレジストリからパッケージを取得していますか？
-    - key: tools_others.package_registries.others
-      t: そのほかのパッケージレジストリ
-    - key: tools_others.package_registries.others.description
-      t: そのほかの回答（自由入力欄）
+  - key: sections.meta_frameworks.title
+    t: Meta-Frameworks
+  - key: sections.meta_frameworks.description
+    t: Frameworks focused on rendering and serving your application
 
-    - key: tools_others.form_factors
-      aliasFor: environments.form_factors
-    - key: tools_others.form_factors.description
-      aliasFor: environments.form_factors.description
+  - key: sections.back_end_frameworks.title
+    t: バックエンドフレームワーク
+  - key: sections.back_end_frameworks.description
+    t: サーバーでのJavaScript
 
-    ###########################################################################
-    # Opinions
-    ###########################################################################
+  - key: sections.testing.title
+    t: テスト
+  - key: sections.testing.description
+    t: コードのテストに使うツール
 
-    - key: opinions.js_moving_in_right_direction
-      t: JavaScriptは正しい方向に進んでいる
+  - key: sections.mobile_desktop.title
+    t: モバイル＆デスクトップ
+  - key: sections.mobile_desktop.description
+    t: モバイルやデスクトップアプリでのJavaScript
 
-    - key: opinions.building_js_apps_overly_complex
-      t: JavaScriptアプリの開発はいまやとても複雑になった
+  - key: sections.build_tools.title
+    t: ビルドツール
+  - key: sections.build_tools.description
+    t: コードのコンパイルとビルド
 
-    - key: opinions.js_over_used_online
-      t: JavaScriptは過剰に使われている
+  - key: sections.monorepo_tools.title
+    t: モノレポのツール
+  - key: sections.monorepo_tools.description
+    t: JavaScriptモノレポの管理に使うツール
 
-    - key: opinions.enjoy_building_js_apps
-      t: JavaScriptアプリの開発は楽しい
+  - key: sections.tools_others.title
+    t: そのほかのツール
+  - key: sections.tools_others.description
+    t: そのほかのJavaScriptツール
 
-    - key: opinions.would_like_js_to_be_main_lang
-      t: JavaScriptをメインのプログラミング言語にしたい
+  - key: sections.other_tools.title
+    t: そのほかのツール
+  - key: sections.other_tools.description
+    t: 以下のツールや技術について、普段使っているものにチェックをつけてください
 
-    - key: opinions.js_ecosystem_changing_to_fast
-      t: JavaScriptエコシステムの変化は速すぎる
+  - key: sections.resources_js.title
+    t: Resources
+  - key: sections.resources_js.description
+    t: What JavaScript resources do you consult?
 
-    - key: opinions_others.missing_from_js.others
-      t: いまのJavaScriptに足りないと感じるものは？
+  - key: sections.usage_js.title
+    t: Usage
+  - key: sections.usage_js.description
+    t: How you use JavaScript
 
-    - key: opinions_others.missing_from_js.others.description
-      t: JavaScriptにいつか追加されてほしい機能
+  ###########################################################################
+  # Survey Help
+  ###########################################################################
 
-    - key: happiness.front_end_frameworks
-      t: フロントエンドフレームワークの現状に満足していますか？
-    - key: happiness.back_end_frameworks
-      t: バックエンドフレームワークの現状に満足していますか？
-    - key: happiness.testing
-      t: テストツールの現状に満足していますか？
-    - key: happiness.mobile_desktop
-      t: モバイル・デスクトップフレームワークの現状に満足していますか？
-    - key: happiness.build_tools
-      t: ビルドツールの現状に満足していますか？
-    - key: happiness.monorepo_tools
-      t: モノレポツールの現状に満足していますか？
+  - key: features.features_intro
+    t: >
+      Welcome to the survey! This first part is all about figuring out 
+      which **features** of the JavaScript language you know about. 
+      And if you know about something but haven't yet used it, that's fine too!
 
-    - key: happiness.state_of_the_web
-      t: ウェブ技術の現状に満足していますか？
+  - key: tools.tools_intro
+    t: >
+      The next couple sections focus on the **libraries** and **frameworks** that make up 
+      the JavaScript ecosystem. Let us know what you're excited about!
 
-    - key: happiness.state_of_js
-      t: JavaScriptの現状に満足していますか？
+  ###########################################################################
+  # Options
+  ###########################################################################
 
-    # Pain Points
-    - key: opinions.js_pain_points
-      t: JavaScriptのつらいところ
-    - key: opinions.js_pain_points.description
-      t: JavaScriptどんなところで苦労するか、対決させてください。
+  # JS pain points
+  # - key: options.js_pain_points.browser_interoperability
+  #   t: Browser Compatibility
+  # - key: options.js_pain_points.browser_interoperability.description
+  #   t: Differences between Chrome, Safari, Firefox, etc.
+  # - key: options.js_pain_points.animations
+  #   t: Animations
+  # - key: options.js_pain_points.animations.description
+  #   t: Managing animations, transitions, etc. using JavaScript.
+  # - key: options.js_pain_points.form_handling
+  #   t: Form Handling
+  # - key: options.js_pain_points.form_handling.description
+  #   t: Creating forms, managing their state and errors, and saving their data.
+  - key: options.js_pain_points.state_management
+    t: ステート管理
+  - key: options.js_pain_points.state_management.description
+    t: 複雑なアプリケーションで、グローバルなデータのステートを管理すること。
+  # - key: options.js_pain_points.performance_issues
+  #   t: Performance Issues
+  # - key: options.js_pain_points.performance_issues.description
+  #   t: Bundle sizes, slow loading, and other performance issues.
+  - key: options.js_pain_points.managing_dependencies
+    t: 依存関係の管理
+  - key: options.js_pain_points.managing_dependencies.description
+    t: 依存関係やパッケージのバージョン、バンドルサイズを管理すること。
+  - key: options.js_pain_points.architecture
+    t: コード設計
+  - key: options.js_pain_points.architecture.description
+    t: コードベースを構造化したり管理すること。
+  - key: options.js_pain_points.finding_packages
+    t: パッケージの検索
+  - key: options.js_pain_points.finding_packages.description
+    t: JavaScriptパッケージを探したり評価すること。
+  - key: options.js_pain_points.writing_modules
+    t: モジュールの作成
+  - key: options.js_pain_points.writing_modules.description
+    t: JavaScriptモジュールを作成したり、パッケージとして公開すること。
+  - key: options.js_pain_points.debugging
+    t: デバッグ
+  - key: options.js_pain_points.debugging.description
+    t: コードの問題点を見つけたり、解決すること。
+  - key: options.js_pain_points.async_code
+    t: 非同期処理
+  - key: options.js_pain_points.async_code.description
+    t: 非同期な関数を処理すること。
+  - key: options.js_pain_points.modules_management
+    t: モジュール管理
+  - key: options.js_pain_points.modules_management.description
+    t: モジュールを書いたり読み込んだりすること。
+  - key: options.js_pain_points.date_management
+    t: 日付や時刻の処理
+  - key: options.js_pain_points.date_management.description
+    t: 日付や時刻を処理したり操作すること。
+  # - key: options.js_pain_points.xxx
+  #   t:
+  # - key: options.js_pain_points.xxx.description
+  #   t:
 
-    - key: opinions_others.js_pain_points.others
-      t: そのほかのJavaScriptのつらいところ
+  - key: options.top_js_pain_points.state_management
+    aliasFor: options.js_pain_points.state_management
+  - key: options.top_js_pain_points.state_management.description
+    aliasFor: options.js_pain_points.state_management.description
+  - key: options.top_js_pain_points.managing_dependencies
+    aliasFor: options.js_pain_points.managing_dependencies
+  - key: options.top_js_pain_points.managing_dependencies.description
+    aliasFor: options.js_pain_points.managing_dependencies.description
+  - key: options.top_js_pain_points.architecture
+    aliasFor: options.js_pain_points.architecture
+  - key: options.top_js_pain_points.architecture.description
+    aliasFor: options.js_pain_points.architecture.description
+  - key: options.top_js_pain_points.finding_packages
+    aliasFor: options.js_pain_points.finding_packages
+  - key: options.top_js_pain_points.finding_packages.description
+    aliasFor: options.js_pain_points.finding_packages.description
+  - key: options.top_js_pain_points.writing_modules
+    aliasFor: options.js_pain_points.writing_modules
+  - key: options.top_js_pain_points.writing_modules.description
+    aliasFor: options.js_pain_points.writing_modules.description
+  - key: options.top_js_pain_points.debugging
+    aliasFor: options.js_pain_points.debugging
+  - key: options.top_js_pain_points.debugging.description
+    aliasFor: options.js_pain_points.debugging.description
+  - key: options.top_js_pain_points.async_code
+    aliasFor: options.js_pain_points.async_code
+  - key: options.top_js_pain_points.async_code.description
+    aliasFor: options.js_pain_points.async_code.description
+  - key: options.top_js_pain_points.modules_management
+    aliasFor: options.js_pain_points.modules_management
+  - key: options.top_js_pain_points.modules_management.description
+    aliasFor: options.js_pain_points.modules_management.description
+  - key: options.top_js_pain_points.date_management
+    aliasFor: options.js_pain_points.date_management
+  - key: options.top_js_pain_points.date_management.description
+    aliasFor: options.js_pain_points.date_management.description
 
-    # Missing Features
-    - key: opinions.currently_missing_from_js
-      t: どんな機能がJavaScriptに足りてないと思いますか？
-    - key: opinions.currently_missing_from_js.description
-      t: JavaScriptにあれば今すぐ使いたいと思う機能について、対決させてください。
-    - key: opinions_others.currently_missing_from_js.others
-      t: そのほかでほしい機能
+  - key: options.top_js_pain_points.performance
+    t: Performance
+  - key: options.top_js_pain_points.performance.description
+    t: Writing performant and efficient JavaScript code
 
-    # pain points/currently missing (results)
-    - key: js_pain_points.js_pain_points_wins
-      t: JavaScriptのつらいところ
-    - key: js_pain_points.js_pain_points_wins.description
-      t: JavaScriptについて、最も悪戦苦闘している点はなんでしょうか？結果はトーナメントの各ラウンドの勝者の数で並べています。
+  - key: options.top_js_pain_points.build_tools
+    t: Build Tools
+  - key: options.top_js_pain_points.build_tools.description
+    t: Managing tooling to bundle your code
 
-    - key: js_pain_points.js_pain_points_matchups
-      t: JavaScriptのつらいところ（対戦）
-    - key: js_pain_points.js_pain_points_matchups.description
-      t: JavaScriptについて、最も悪戦苦闘している点はなんでしょうか？結果は左方の技術が上方の技術に勝ったラウンドの割合を示しています。
+  - key: options.top_js_pain_points.typing
+    t: Typing
+  - key: options.top_js_pain_points.typing.description
+    t: Managing and maintaining types
 
-    - key: currently_missing_from_js.currently_missing_from_js_wins
-      t: JavaScriptに足りていない機能
-    - key: currently_missing_from_js.currently_missing_from_js_wins.description
-      t: JavaScriptについて、いま使えたらなと最も思う機能はなんでしょうか？結果はトーナメントの各ラウンドの勝者の数で並べています。
+  - key: options.top_js_pain_points.build_tools
+    t: Build Tools
+  - key: options.top_js_pain_points.typing
+    t: Typing
+  - key: options.top_js_pain_points.typescript
+    t: TypeScript
+  - key: options.top_js_pain_points.esm_cjs
+    t: ESM vs CJS
+  - key: options.top_js_pain_points.testing
+    t: Testing
+  - key: options.top_js_pain_points.performance
+    t: Performance
+  - key: options.top_js_pain_points.too_many_choices
+    t: Too Many Choices
+  - key: options.top_js_pain_points.react
+    t: React
+  - key: options.top_js_pain_points.bundlers
+    t: Bundlers
+  - key: options.top_js_pain_points.complexity
+    t: Complexity
+  - key: options.top_js_pain_points.standard_library
+    t: Standard Library
+  - key: options.top_js_pain_points.tooling
+    t: Tooling
+  - key: options.top_js_pain_points.dependencies
+    t: Dependencies
+  - key: options.top_js_pain_points.security
+    t: Security
+  - key: options.top_js_pain_points.slow
+    t: Slowness
 
-    - key: currently_missing_from_js.currently_missing_from_js_matchups
-      t: JavaScriptに足りていない機能（対戦）
-    - key: currently_missing_from_js.currently_missing_from_js_matchups.description
-      t: JavaScriptについて、いま使えたらなと最も思う機能はなんでしょうか？結果は左方の技術が上方の技術に勝ったラウンドの割合を示しています。
+  # JS missing features
+  - key: options.currently_missing_from_js.static_typing
+    t: 静的型付け
+  - key: options.currently_missing_from_js.static_typing.description
+    t: 型のネイティブサポート（TypeScriptと同様の機能）。
+  - key: options.currently_missing_from_js.standard_library
+    t: 標準ライブラリ
+  - key: options.currently_missing_from_js.standard_library.description
+    t: 共通ユーティリティの標準ライブラリ。
+  - key: options.currently_missing_from_js.pattern_matching
+    t: パターンマッチ
+  - key: options.currently_missing_from_js.pattern_matching.description
+    t: オブジェクトのパターンマッチに使う新しい`match`キーワード。
+  - key: options.currently_missing_from_js.pipe_operator
+    t: パイプ演算子
+  - key: options.currently_missing_from_js.pipe_operator.description
+    t: 関数の結果を別の関数に渡す新しい`|>`演算子。
+  - key: options.currently_missing_from_js.decorators
+    t: デコレータ
+  - key: options.currently_missing_from_js.decorators.description
+    t: メタプログラミングや値に処理を付加するデコレータ。
+  - key: options.currently_missing_from_js.immutable_data_structures
+    t: イミュータブルなデータ構造
+  - key: options.currently_missing_from_js.immutable_data_structures.description
+    t: '`Record`や`Tuple`など、より徹底したイミュータブルなデータ構造。'
+  - key: options.currently_missing_from_js.better_date_management
+    t: より良い日付管理
+  - key: options.currently_missing_from_js.better_date_management.description
+    t: 日付や時刻を処理するための新しい`Temporal`オブジェクト。
+  - key: options.currently_missing_from_js.observable
+    t: Observable
+  - key: options.currently_missing_from_js.observable.description
+    t: プッシュベースなデータソースのモデリングに使う新しい型`Observable`。
+  # - key: options.currently_missing_from_js.xxx
+  #   t:
+  # - key: options.currently_missing_from_js.xxx.description
+  #   t:
 
-    ###########################################################################
-    # Resources
-    ###########################################################################
+  - key: options.top_currently_missing_from_js.static_typing
+    aliasFor: options.currently_missing_from_js.static_typing
+  - key: options.top_currently_missing_from_js.static_typing.description
+    aliasFor: options.currently_missing_from_js.static_typing.description
+  - key: options.top_currently_missing_from_js.standard_library
+    aliasFor: options.currently_missing_from_js.standard_library
+  - key: options.top_currently_missing_from_js.standard_library.description
+    aliasFor: options.currently_missing_from_js.standard_library.description
+  - key: options.top_currently_missing_from_js.pattern_matching
+    aliasFor: options.currently_missing_from_js.pattern_matching
+  - key: options.top_currently_missing_from_js.pattern_matching.description
+    aliasFor: options.currently_missing_from_js.pattern_matching.description
+  - key: options.top_currently_missing_from_js.pipe_operator
+    aliasFor: options.currently_missing_from_js.pipe_operator
+  - key: options.top_currently_missing_from_js.pipe_operator.description
+    aliasFor: options.currently_missing_from_js.pipe_operator.description
+  - key: options.top_currently_missing_from_js.decorators
+    aliasFor: options.currently_missing_from_js.decorators
+  - key: options.top_currently_missing_from_js.decorators.description
+    aliasFor: options.currently_missing_from_js.decorators.description
+  - key: options.top_currently_missing_from_js.immutable_data_structures
+    aliasFor: options.currently_missing_from_js.immutable_data_structures
+  - key: options.top_currently_missing_from_js.immutable_data_structures.description
+    aliasFor: options.currently_missing_from_js.immutable_data_structures.description
+  - key: options.top_currently_missing_from_js.better_date_management
+    aliasFor: options.currently_missing_from_js.better_date_management
+  - key: options.top_currently_missing_from_js.better_date_management.description
+    aliasFor: options.currently_missing_from_js.better_date_management.description
+  - key: options.top_currently_missing_from_js.observable
+    aliasFor: options.currently_missing_from_js.observable
+  - key: options.top_currently_missing_from_js.observable.description
+    aliasFor: options.currently_missing_from_js.observable.description
 
-    - key: resources.first_steps_js
-      t: JavaScriptの最初の勉強方法
-    - key: resources.first_steps_js.description
-      t: 最初にJavaScriptを学び始めたとき、どの方法で学びましたか。
+  - key: options.top_currently_missing_from_js.static_typing
+    t: Static Typing
+  - key: options.top_currently_missing_from_js.standard_library
+    t: Standard Library
+  - key: options.top_currently_missing_from_js.operator_overloading
+    t: Operator Overloading
+  - key: options.top_currently_missing_from_js.immutable
+    t: Immutable Data Structures
+  - key: options.top_currently_missing_from_js.deep_clone
+    t: Deep Clone
+  - key: options.top_currently_missing_from_js.enums
+    t: Enums
+  - key: options.top_currently_missing_from_js.decorators
+    t: Decorators
+  - key: options.top_currently_missing_from_js.multithreading
+    t: Multithreading
+  - key: options.top_currently_missing_from_js.pipe_operator
+    t: Pipe Operator
+  - key: options.top_currently_missing_from_js.native_observables
+    t: Native Observables
+
+  # What do you use JS for?
+  - key: options.what_do_you_use_js_for.frontend_development
+    t: Frontend Development
+  - key: options.what_do_you_use_js_for.backend_development
+    t: Backend Development
+  - key: options.what_do_you_use_js_for.data_analysis
+    t: Data Analysis
+  - key: options.what_do_you_use_js_for.machine_learning
+    t: Machine Learning
+  - key: options.what_do_you_use_js_for.desktop_apps
+    t: Desktop Apps
+  - key: options.what_do_you_use_js_for.mobile_apps
+    t: Mobile Apps
+  - key: options.what_do_you_use_js_for.embedded_apps
+    t: Embedded Apps
+  - key: options.what_do_you_use_js_for.game_development
+    t: Game Development
+  - key: options.what_do_you_use_js_for.data_visualization
+    t: Data Visualization
+  - key: options.what_do_you_use_js_for.graphics_animation
+    t: Graphics & Animation
+
+  - key: options.what_do_you_use_js_for.scripting
+    t: Scripting
+  - key: options.what_do_you_use_js_for.command_line_tools
+    t: Command Line Tools
+  - key: options.what_do_you_use_js_for.developer_tooling
+    t: Developer Tooling
+  - key: options.what_do_you_use_js_for.automation
+    t: Automation
+  - key: options.what_do_you_use_js_for.bots
+    t: Bots
+  - key: options.what_do_you_use_js_for.testing
+    t: Testing
+  - key: options.what_do_you_use_js_for.browser_extensions
+    t: Browser Extensions
+  - key: options.what_do_you_use_js_for.api
+    t: APIs
+  - key: options.what_do_you_use_js_for.infrastructure_as_code
+    t: Infrastructure as Code
+  - key: options.what_do_you_use_js_for.prototyping
+    t: Prototyping
+
+  # JS App Patterns
+
+  - key: options.js_app_patterns.single_page_app
+    t: Single Page Application (SPA)
+  - key: options.js_app_patterns.single_page_app.description
+    t: Apps that run entirely in the browser
+  - key: options.js_app_patterns.multiple_page_app
+    t: Multi-Page Application (MPA)
+  - key: options.js_app_patterns.multiple_page_app.description
+    t: Apps that run entirely on the server, with minimal client-side dynamic behavior
+  - key: options.js_app_patterns.static_site_generation
+    t: Static Site Generation (SSG)
+  - key: options.js_app_patterns.static_site_generation.description
+    t: Static content pre-rendered at build time, with or without a client-side dynamic element
+  - key: options.js_app_patterns.server_side_rendering
+    t: Server-Side Rendering (SSR)
+  - key: options.js_app_patterns.server_side_rendering.description
+    t: Dynamically rendering HTML content on the server on request, before rehydrating it on the client
+  - key: options.js_app_patterns.partial_hydration
+    t: Partial Hydration
+  - key: options.js_app_patterns.partial_hydration.description
+    t: Only hydrating some of your components on the client (e.g. React Server Components)
+  - key: options.js_app_patterns.progressive_rehydration
+    t: Progressive Hydration
+  - key: options.js_app_patterns.progressive_rehydration.description
+    t: Controlling the order of component hydration on the client
+  - key: options.js_app_patterns.islands_architecture
+    t: Islands Architecture
+  - key: options.js_app_patterns.islands_architecture.description
+    t: Isolated islands of dynamic behavior with multiple entry points in an otherwise static site (Astro, Eleventy)
+  - key: options.js_app_patterns.progressive_enhancement
+    t: Progressive Enhancement
+  - key: options.js_app_patterns.progressive_enhancement.description
+    t: Making sure an app is functional even without JavaScript
+  - key: options.js_app_patterns.incremental_static_generation
+    t: Incremental Static Generation
+  - key: options.js_app_patterns.incremental_static_generation.description
+    t: Being able to dynamically augment or modify a static site even after the initial build (Next.js ISR & on-demand revalidation, Gatsby DSG)
+  - key: options.js_app_patterns.streaming_ssr
+    t: Streaming SSR
+  - key: options.js_app_patterns.streaming_ssr.description
+    t: Breaking down server-rendered content in smaller streamed chunks
+  - key: options.js_app_patterns.resumability
+    t: Resumability
+  - key: options.js_app_patterns.resumability.description
+    t: Serializing framework state on the server so the client can resume execution with no duplicated code execution.
+  - key: options.js_app_patterns.edge_rendering
+    t: Edge Rendering
+  - key: options.js_app_patterns.edge_rendering.description
+    t: Altering rendered HTML at the edge before sending it on to the client
+  - key: options.js_app_patterns.partial_prerendering
+    t: Partial Prerendering
+  - key: options.js_app_patterns.partial_prerendering.description
+    t: Render a route with a static loading shell, while keeping some parts dynamic
+
+  - key: options.js_app_patterns.micro_frontend
+    t: Micro Frontend
+  - key: options.js_app_patterns.domain_driven_design
+    t: Domain-Driven Design
+  - key: options.js_app_patterns.serverless
+    t: Serverless
+  - key: options.js_app_patterns.pespa
+    t: PESPA
+
+  # slider
+  - key: options.js_ts_balance.0
+    t: 100% JS
+  - key: options.js_ts_balance.1
+    t: "|"
+  - key: options.js_ts_balance.2
+    t: "|"
+  - key: options.js_ts_balance.3
+    t: "|"
+  - key: options.js_ts_balance.4
+    t: "50/50"
+  - key: options.js_ts_balance.5
+    t: "|"
+  - key: options.js_ts_balance.6
+    t: "|"
+  - key: options.js_ts_balance.7
+    t: "|"
+  - key: options.js_ts_balance.8
+    t: 100% TS
+
+  ###########################################################################
+  # Features
+  ###########################################################################
+
+  # syntax
+  - key: features.destructuring
+    t: 分割代入（destructuring）
+  - key: features.spread_operator
+    t: スプレッド構文
+  - key: features.arrow_functions
+    t: アロー関数（arrow functions）
+  - key: features.nullish_coalescing
+    t: Nullish Coalescing
+  - key: features.optional_chaining
+    t: Optional Chaining
+  - key: features.private_fields
+    t: プライベートフィールド
+
+  # language
+  - key: features.proxies
+    t: Proxy
+  - key: features.async_await
+    t: Async/Await
+  - key: features.promises
+    t: Promise
+  - key: features.decorators
+    t: デコレータ
+  - key: features.decorators.description
+    t: デコレータを簡単に言うと、コードの一部を別のコードでラップする（文字通り「デコレート」する）仕組みです。
+  - key: features.dynamic_import
+    t: Dynamic Import
+
+  - key: features.syntax_features
+    t: Syntax Features
+  - key: features.syntax_features.question
+    t: Which of these syntax features have you used?
+
+  - key: features.string_features
+    t: String Features
+  - key: features.string_features.question
+    t: Which of these String features have you used?
+
+  - key: features.array_features
+    t: Array Features
+  - key: features.array_features.question
+    t: Which of these Array features have you used?
+
+  - key: features.async_features
+    t: Async Features
+  - key: features.async_features.question
+    t: Which of these async features have you used?
+
+  - key: features.browser_api_features
+    t: Browser APIs
+  - key: features.browser_api_features.question
+    t: Which of these browser APIs have you used?
+
+  - key: features.language_pain_points
+    t: Language Pain Points
+  - key: features.language_pain_points.question
+    t: What are your main pain points regarding the JavaScript language?
+
+  - key: features.browser_apis_pain_points
+    t: Browser APIs Pain Points
+  - key: features.browser_apis_pain_points.question
+    t: What are your main pain points regarding browser APIs?
+
+  # patterns
+  - key: patterns.object_oriented_programming
+    t: オブジェクト指向プログラミング
+  - key: features.functional_programming
+    t: 関数型プログラミング
+  - key: features.reactive_programming
+    t: リアクティブプログラミング
+
+  # upcoming features
+  # - key: features.static_typing
+  #   t: Static Typing
+
+  # - key: features.standard_library
+  #   t: Standard Library
+
+  # - key: features.pattern_matching
+  #   t: Pattern Matching
+
+  # - key: features.pipe_operator
+  #   t: Pipe Operator
+
+  # - key: features.immutable_data_structures
+  #   t: Immutable Data Structures
+
+  ###########################################################################
+  # Tools
+  ###########################################################################
+
+  - key: tools.angular.description
+    t: これは[Angular](https://angular.io/)についてで、非推奨になった[AngularJS](https://angularjs.org/)のものではないことに注意してください。
+
+  - key: tools.best_of_js_projects.note
+    t: >
+      Libraries are loaded from [Best of JS](https://bestofjs.org/). 
+      If a project is missing, you can [submit it here](https://github.com/michaelrambeau/bestofjs/issues/new?template=add-a-project-to-best-of-javascript.md).
+
+  # front-end frameworks
+  - key: tools.front_end_frameworks_happiness
+    t: Front-end Frameworks Happiness
+  - key: tools.front_end_frameworks_happiness.question
+    t: How happy are you with the current state of front-end frameworks?
+
+  - key: tools.front_end_frameworks_pain_points
+    t: Front-end Frameworks Pain Points
+  - key: tools.front_end_frameworks_pain_points.question
+    t: What pain points have you encountered when using front-end frameworks?
+
+  # meta-frameworks
+
+  - key: tools.meta_frameworks_happiness
+    t: Meta-Frameworks Happiness
+  - key: tools.meta_frameworks_happiness.question
+    t: How happy are you with the current state of meta-frameworks?
+
+  - key: tools.meta_frameworks_pain_points
+    t: Meta-Frameworks Pain Points
+  - key: tools.meta_frameworks_pain_points.question
+    t: What pain points have you encountered when using meta-frameworks?
+
+  # testing
+
+  - key: tools.testing_happiness
+    t: Testing Happiness
+  - key: tools.testing_happiness.question
+    t: How happy are you with the current state of testing tools?
+
+  - key: tools.testing_pain_points
+    t: Testing Pain Points
+  - key: tools.testing_pain_points.question
+    t: What pain points have you encountered when using testing tools?
+
+  # mobile & desktop
+
+  - key: tools.mobile_desktop_happiness
+    t: Mobile & Desktop Happiness
+  - key: tools.mobile_desktop_happiness.question
+    t: How happy are you with the current state of mobile & desktop tools?
+
+  - key: tools.mobile_desktop_pain_points
+    t: Mobile & Desktop Pain Points
+  - key: tools.mobile_desktop_pain_points.question
+    t: What pain points have you encountered when using JavaScript to build mobile & desktop apps?
+
+  # build tools
+
+  - key: tools.build_tools_happiness
+    t: Build Tools Happiness
+  - key: tools.build_tools_happiness.question
+    t: How happy are you with the current state of build tools?
+
+  - key: tools.build_tools_pain_points
+    t: Build Tools Pain Points
+  - key: tools.build_tools_pain_points.question
+    t: What pain points have you encountered when using build tools?
+
+  # monorepo tools
+
+  - key: tools.monorepo_tools_happiness
+    t: Monorepo Happiness
+  - key: tools.monorepo_tools_happiness.question
+    t: How happy are you with the current state of monorepo tools?
+
+  - key: tools.monorepo_tools_pain_points
+    t: Monorepo Pain Points
+  - key: tools.monorepo_tools_pain_points.question
+    t: What pain points have you encountered when using monorepo tools?
+
+  ###########################################################################
+  # Other Tools
+  ###########################################################################
+
+  - key: tools_others.libraries
+    t: Libraries
+  - key: tools_others.libraries.description
+    t: Which libraries do you regularly use?
+  - key: tools_others.libraries.others
+    t: Other Libraries
+  - key: tools_others.libraries.others.description
+    t: Other answers (freeform field).
+
+  - key: tools_others.text_editors
+    t: Text Editors
+  - key: tools_others.text_editors.description
+    t: Which text editor(s) do you regularly use?
+  - key: tools_others.text_editors.others
+    t: Other Text Editors
+  - key: tools_others.text_editors.others.description
+    t: Other answers (freeform field).
+
+  - key: tools_others.utilities
+    t: Utilities
+  - key: tools_others.utilities.description
+    t: Which utilities or tools do you regularly use?
+  - key: tools_others.utilities.others
+    t: Other Utilities
+  - key: tools_others.utilities.others.description
+    t: Other utilities (freeform field).
+
+  - key: tools_others.browsers
+    t: Browsers
+  - key: tools_others.browsers.description
+    t: Which browser(s) do you primarily work in during initial development?
+  - key: tools_others.browsers.others
+    t: Other Browsers
+  - key: tools_others.browsers.others.description
+    t: Other answers (freeform field).
+
+  - key: tools_others.build_tools
+    t: Build Tools
+  - key: tools_others.build_tools.description
+    t: Which build tools do you use?
+  - key: tools_others.build_tools.others
+    t: Other Build Tools
+  - key: tools_others.build_tools.others.description
+    t: Other answers (freeform field).
+
+  - key: tools_others.non_js_languages
+    t: Non-JavaScript Languages
+  - key: tools_others.non_js_languages.description
+    t: Which other programming languages do you use?
+  - key: tools_others.non_js_languages.others
+    t: Other Languages
+  - key: tools_others.non_js_languages.others.description
+    t: Other answers (freeform field).
+
+  - key: tools_others.javascript_flavors
+    t: JavaScript Flavors
+  - key: tools_others.javascript_flavors.description
+    t: Languages that compile to JavaScript
+  - key: tools_others.javascript_flavors.others
+    t: Other JavaScript Flavors
+  - key: tools_others.javascript_flavors.others.description
+    t: Other answers (freeform field).
+
+  - key: tools_others.runtimes
+    t: JavaScriptランタイム
+  - key: tools_others.runtimes.description
+    t: いつもどのエンジン・ランタイム・実行環境を使っていますか？
+  - key: tools_others.runtimes.others
+    t: そのほかのランタイム
+  - key: tools_others.runtimes.others.description
+    t: そのほかの回答（自由入力欄）
+
+  - key: tools_others.package_registries
+    t: パッケージレジストリ
+  - key: tools_others.package_registries.description
+    t: いつもどのレジストリからパッケージを取得していますか？
+  - key: tools_others.package_registries.others
+    t: そのほかのパッケージレジストリ
+  - key: tools_others.package_registries.others.description
+    t: そのほかの回答（自由入力欄）
+
+  - key: tools_others.form_factors
+    aliasFor: environments.form_factors
+  - key: tools_others.form_factors.description
+    aliasFor: environments.form_factors.description
+
+  - key: tools_others.backend_as_a_service
+    t: Backend-as-a-Service Providers
+  - key: tools_others.backend_as_a_service.description
+    t: Services that host your data and offer a client API to access it.
+  - key: tools_others.backend_as_a_service.others
+    t: Other BaaS Providers
+
+  - key: tools_others.date_management
+    t: Date Management
+  - key: tools_others.date_management.description
+    t: Libraries that help with date and timezone management.
+  - key: tools_others.date_management.others
+    t: Other Date Management Libraries
+
+  - key: tools_others.data_visualization
+    t: Data Visualization
+  - key: tools_others.data_visualization.description
+    t: Libraries that help with charts and other data visualizations.
+  - key: tools_others.data_visualization.others
+    t: Other Data Visualization Libraries
+
+  - key: tools_others.graphics_animation
+    t: Graphics & Animations
+  - key: tools_others.graphics_animation.description
+    t: Libraries dedicated to graphics and animation.
+  - key: tools_others.graphics_animation.others
+    t: Other Graphics & Animations Libraries
+
+  - key: tools_others.data_fetching
+    t: Data Fetching
+  - key: tools_others.data_fetching.description
+    t: Libraries that manage data fetching and caching.
+  - key: tools_others.data_fetching.others
+    t: Other Data Fetching Libraries
+
+  - key: other_tools.libraries
+    aliasFor: tools_others.libraries
+  - key: other_tools.libraries.description
+    aliasFor: tools_others.libraries.description
+  - key: other_tools.libraries.others
+    aliasFor: tools_others.libraries.others
+  - key: other_tools.libraries.others.description
+    aliasFor: tools_others.libraries.others.description
+
+  - key: other_tools.text_editors
+    aliasFor: tools_others.text_editors
+  - key: other_tools.text_editors.description
+    aliasFor: tools_others.text_editors.description
+  - key: other_tools.text_editors.others
+    aliasFor: tools_others.text_editors.others
+  - key: other_tools.text_editors.others.description
+    aliasFor: tools_others.text_editors.others.description
+
+  - key: other_tools.utilities
+    aliasFor: tools_others.utilities
+  - key: other_tools.utilities.description
+    aliasFor: tools_others.utilities.description
+  - key: other_tools.utilities.others
+    aliasFor: tools_others.utilities.others
+  - key: other_tools.utilities.others.description
+    aliasFor: tools_others.utilities.others.description
+
+  - key: other_tools.browsers
+    aliasFor: tools_others.browsers
+  - key: other_tools.browsers.description
+    aliasFor: tools_others.browsers.description
+  - key: other_tools.browsers.others
+    aliasFor: tools_others.browsers.others
+  - key: other_tools.browsers.others.description
+    aliasFor: tools_others.browsers.others.description
+
+  - key: other_tools.build_tools
+    aliasFor: tools_others.build_tools
+  - key: other_tools.build_tools.description
+    aliasFor: tools_others.build_tools.description
+  - key: other_tools.build_tools.others
+    aliasFor: tools_others.build_tools.others
+  - key: other_tools.build_tools.others.description
+    aliasFor: tools_others.build_tools.others.description
+
+  - key: other_tools.non_js_languages
+    aliasFor: tools_others.non_js_languages
+  - key: other_tools.non_js_languages.description
+    aliasFor: tools_others.non_js_languages.description
+  - key: other_tools.non_js_languages.others
+    aliasFor: tools_others.non_js_languages.others
+  - key: other_tools.non_js_languages.others.description
+    aliasFor: tools_others.non_js_languages.others.description
+
+  - key: other_tools.javascript_flavors
+    aliasFor: tools_others.javascript_flavors
+  - key: other_tools.javascript_flavors.description
+    aliasFor: tools_others.javascript_flavors.description
+  - key: other_tools.javascript_flavors.others
+    aliasFor: tools_others.javascript_flavors.others
+  - key: other_tools.javascript_flavors.others.description
+    aliasFor: tools_others.javascript_flavors.others.description
+
+  - key: tools_others.backend_frameworks
+    aliasFor: sections.back_end_frameworks.title
+  - key: tools_others.backend_frameworks.description
+    t: Frameworks for generating APIs and managing back-ends
+  - key: tools_others.backend_frameworks.others
+    t: Other Back-end Frameworks
+
+  - key: other_tools.runtimes
+    aliasFor: tools_others.runtimes
+  - key: other_tools.runtimes.description
+    aliasFor: tools_others.runtimes.description
+  - key: other_tools.runtimes.others
+    aliasFor: tools_others.runtimes.others
+  - key: other_tools.runtimes.others.description
+    aliasFor: tools_others.runtimes.others.description
+
+  - key: other_tools.package_registries
+    aliasFor: tools_others.package_registries
+  - key: other_tools.package_registries.description
+    aliasFor: tools_others.package_registries.description
+  - key: other_tools.package_registries.others
+    aliasFor: tools_others.package_registries.others
+  - key: other_tools.package_registries.others.description
+    aliasFor: tools_others.package_registries.others.description
+
+  - key: other_tools.form_factors
+    aliasFor: tools_others.form_factors
+  - key: other_tools.form_factors.description
+    aliasFor: tools_others.form_factors.description
+
+  - key: other_tools.backend_as_a_service
+    aliasFor: tools_others.backend_as_a_service
+  - key: other_tools.backend_as_a_service.description
+    aliasFor: tools_others.backend_as_a_service.description
+  - key: other_tools.backend_as_a_service.others
+    aliasFor: tools_others.backend_as_a_service.others
+
+  - key: other_tools.date_management
+    aliasFor: tools_others.date_management
+  - key: other_tools.date_management.description
+    aliasFor: tools_others.date_management.description
+  - key: other_tools.date_management.others
+    aliasFor: tools_others.date_management.others
+
+  - key: other_tools.data_visualization
+    aliasFor: tools_others.data_visualization
+  - key: other_tools.data_visualization.description
+    aliasFor: tools_others.data_visualization.description
+  - key: other_tools.data_visualization.others
+    aliasFor: tools_others.data_visualization.others
+
+  - key: other_tools.graphics_animation
+    aliasFor: tools_others.graphics_animation
+  - key: other_tools.graphics_animation.description
+    aliasFor: tools_others.graphics_animation.description
+  - key: other_tools.graphics_animation.others
+    aliasFor: tools_others.graphics_animation.others
+
+  - key: other_tools.data_fetching
+    aliasFor: tools_others.data_fetching
+  - key: other_tools.data_fetching.description
+    aliasFor: tools_others.data_fetching.description
+  - key: other_tools.data_fetching.others
+    aliasFor: tools_others.data_fetching.others
+
+  - key: other_tools.backend_frameworks
+    aliasFor: tools_others.backend_frameworks
+  - key: other_tools.backend_frameworks.description
+    aliasFor: tools_others.backend_frameworks.description
+  - key: other_tools.backend_frameworks.others
+    aliasFor: tools_others.backend_frameworks.others
+
+  - key: other_tools.ai_tools
+    t: AI Tools
+  - key: other_tools.ai_tools.question
+    t: Which of these AI tools do you regularly use to help you write code?
+
+  - key: other_tools.hosting
+    t: Hosting Services
+  - key: other_tools.hosting.question
+    t: Which of these services have you used to host JavaScript apps?
+
+  ###########################################################################
+  # Usage
+  ###########################################################################
+
+  - key: usage.js_app_patterns
+    t: Application Patterns
+  - key: usage.js_app_patterns.question
+    t: Which of the following architecture and rendering patterns have you used **in the last year**?
+  - key: usage.js_app_patterns.others
+    t: Other App Patterns
+
+  - key: usage.what_do_you_use_js_for
+    t: JavaScript Usage
+  - key: usage.what_do_you_use_js_for.question
+    t: What do you use JavaScript for?
+  - key: usage.what_do_you_use_js_for.others
+    t: Other JavaScript Use Cases
+
+  - key: usage.js_ts_balance
+    t: JavaScript/TypeScript Balance
+  - key: usage.js_ts_balance.question
+    t: How do you divide your time between writing JavaScript and TypeScript code?
+
+  - key: tools_others.edge_runtimes
+    t: JavaScript Edge/Serverless Runtimes
+  - key: tools_others.edge_runtimes.question
+    t: Which edge or serverless runtimes do you regularly use?
+  - key: tools_others.edge_runtimes.others
+    t: Other Edge Runtimes
+  - key: other_tools.edge_runtimes
+    aliasFor: tools_others.edge_runtimes
+  - key: other_tools.edge_runtimes.description
+    aliasFor: tools_others.edge_runtimes.question
+
+  - key: usage.usage_type
+    t: JavaScript Usage
+  - key: usage.usage_type.question
+    t: In what context do you primarily use JavaScript?
+  - key: usage.usage_type.others
+    t: Other Usages
+
+  - key: opinions.pick_of_the_year
+    t: Your “Pick of the Year”
+  - key: opinions.pick_of_the_year.description
+    t: The name of a feature, library, website, person, etc. you want to highlight this year.
+
+  - key: usage.industry_sector_js
+    aliasFor: usage.industry_sector
+  - key: usage.industry_sector_js.question
+    t: Which industry sector(s) are you using JavaScript in?
+  - key: usage.industry_sector_js.others
+    aliasFor: usage.industry_sector.others
+
+  ###########################################################################
+  # Opinions
+  ###########################################################################
+
+  - key: opinions.js_moving_in_right_direction
+    t: JavaScriptは正しい方向に進んでいる
+
+  - key: opinions.building_js_apps_overly_complex
+    t: JavaScriptアプリの開発はいまやとても複雑になった
+
+  - key: opinions.js_over_used_online
+    t: JavaScriptは過剰に使われている
+
+  - key: opinions.enjoy_building_js_apps
+    t: JavaScriptアプリの開発は楽しい
+
+  - key: opinions.would_like_js_to_be_main_lang
+    t: JavaScriptをメインのプログラミング言語にしたい
+
+  - key: opinions.js_ecosystem_changing_to_fast
+    t: JavaScriptエコシステムの変化は速すぎる
+
+  - key: opinions_others.missing_from_js.others
+    t: いまのJavaScriptに足りないと感じるものは？
+  - key: opinions_others.missing_from_js.others.description
+    t: JavaScriptにいつか追加されてほしい機能
+
+  - key: happiness.front_end_frameworks
+    t: フロントエンドフレームワークの現状に満足していますか？
+  - key: happiness.back_end_frameworks
+    t: バックエンドフレームワークの現状に満足していますか？
+  - key: happiness.testing
+    t: テストツールの現状に満足していますか？
+  - key: happiness.mobile_desktop
+    t: モバイル・デスクトップフレームワークの現状に満足していますか？
+  - key: happiness.build_tools
+    t: ビルドツールの現状に満足していますか？
+  - key: happiness.monorepo_tools
+    t: モノレポツールの現状に満足していますか？
+  - key: happiness.rendering_frameworks
+    t: How happy are you with the state of rendering frameworks?
+
+  - key: happiness.state_of_the_web
+    t: ウェブ技術の現状に満足していますか？
+  - key: happiness.state_of_the_web.question
+    t: How happy are you with the general state of web technologies?
+
+  - key: happiness.state_of_js
+    t: JavaScriptの現状に満足していますか？
+  - key: happiness.state_of_js.question
+    t: How happy are you with the general state of JavaScript?
+
+  # Pain Points
+
+  - key: usage.top_js_pain_points
+    aliasFor: opinions.js_pain_points
+  - key: usage.top_js_pain_points.question
+    t: What aspects of JavaScript do you struggle with the most?
+
+  - key: opinions.js_pain_points
+    t: JavaScriptのつらいところ
+  - key: opinions.js_pain_points.description
+    t: JavaScriptどんなところで苦労するか、対決させてください。
+  - key: opinions_others.js_pain_points.others
+    t: そのほかのJavaScriptのつらいところ
+
+  - key: opinions.top_js_pain_points
+    aliasFor: opinions.js_pain_points
+  - key: opinions.top_js_pain_points.description
+    t: Pick the top 3 aspects of JavaScript you struggle with the most.
+  - key: opinions_others.top_js_pain_points.others
+    aliasFor: opinions_others.js_pain_points.others
+  - key: opinions.top_js_pain_points.others
+    aliasFor: opinions_others.js_pain_points.others
+
+  # Missing Features
+
+  - key: usage.top_currently_missing_from_js
+    t: Missing Features
+  - key: usage.top_currently_missing_from_js.question
+    aliasFor: opinions.currently_missing_from_js
+
+  - key: opinions.currently_missing_from_js
+    t: どんな機能がJavaScriptに足りてないと思いますか？
+  - key: opinions.currently_missing_from_js.description
+    t: JavaScriptにあれば今すぐ使いたいと思う機能について、対決させてください。
+  - key: opinions_others.currently_missing_from_js.others
+    t: そのほかでほしい機能
+
+  - key: opinions.top_currently_missing_from_js
+    aliasFor: opinions.currently_missing_from_js
+  - key: opinions.top_currently_missing_from_js.description
+    t: Pick the top 3 features you'd most like to be able to use in JavaScript today.
+  - key: opinions_others.top_currently_missing_from_js.others
+    aliasFor: opinions_others.currently_missing_from_js.others
+  - key: opinions.top_currently_missing_from_js.others
+    aliasFor: opinions_others.currently_missing_from_js.others
+
+  # pain points/currently missing (results)
+  - key: js_pain_points.js_pain_points_wins
+    t: JavaScriptのつらいところ
+  - key: js_pain_points.js_pain_points_wins.description
+    t: JavaScriptについて、最も悪戦苦闘している点はなんでしょうか？結果はトーナメントの各ラウンドの勝者の数で並べています。
+
+  - key: js_pain_points.js_pain_points_matchups
+    t: JavaScriptのつらいところ（対戦）
+  - key: js_pain_points.js_pain_points_matchups.description
+    t: JavaScriptについて、最も悪戦苦闘している点はなんでしょうか？結果は左方の技術が上方の技術に勝ったラウンドの割合を示しています。
+
+  - key: currently_missing_from_js.currently_missing_from_js_wins
+    t: JavaScriptに足りていない機能
+  - key: currently_missing_from_js.currently_missing_from_js_wins.description
+    t: JavaScriptについて、いま使えたらなと最も思う機能はなんでしょうか？結果はトーナメントの各ラウンドの勝者の数で並べています。
+
+  - key: currently_missing_from_js.currently_missing_from_js_matchups
+    t: JavaScriptに足りていない機能（対戦）
+  - key: currently_missing_from_js.currently_missing_from_js_matchups.description
+    t: JavaScriptについて、いま使えたらなと最も思う機能はなんでしょうか？結果は左方の技術が上方の技術に勝ったラウンドの割合を示しています。
+
+  ###########################################################################
+  # Resources
+  ###########################################################################
+
+  - key: resources.first_steps_js
+    t: JavaScriptの最初の勉強方法
+  - key: resources.first_steps_js.description
+    t: 最初にJavaScriptを学び始めたとき、どの方法で学びましたか。

--- a/state_of_js.yml
+++ b/state_of_js.yml
@@ -26,9 +26,9 @@ translations:
   ###########################################################################
 
   - key: sections.features.title
-    t: Features
+    t: 機能
   - key: sections.features.description
-    t: Syntax, browser APIs, and other features.
+    t: 構文、ブラウザAPI、その他の機能
 
   - key: sections.syntax.title
     t: 構文
@@ -76,14 +76,14 @@ translations:
     t: アプリでのデータの読み込みや管理
 
   - key: sections.rendering_frameworks.title
-    t: Rendering Frameworks
+    t: レンダリングフレームワーク
   - key: sections.rendering_frameworks.description
-    t: Frameworks focused on rendering and serving your application
+    t: アプリケーションのレンダリングと配信に重点を置いたフレームワーク
 
   - key: sections.meta_frameworks.title
-    t: Meta-Frameworks
+    t: メタフレームワーク
   - key: sections.meta_frameworks.description
-    t: Frameworks focused on rendering and serving your application
+    t: アプリケーションのレンダリングと配信に重点を置いたフレームワーク
 
   - key: sections.back_end_frameworks.title
     t: バックエンドフレームワーク
@@ -121,29 +121,24 @@ translations:
     t: 以下のツールや技術について、普段使っているものにチェックをつけてください
 
   - key: sections.resources_js.title
-    t: Resources
+    t: リソース
   - key: sections.resources_js.description
-    t: What JavaScript resources do you consult?
+    t: 参照したことがあるJavaScriptのリソースはなんですか？
 
   - key: sections.usage_js.title
-    t: Usage
+    t: 使用状況
   - key: sections.usage_js.description
-    t: How you use JavaScript
+    t: どのようにJavaScriptを使用していますか？
 
   ###########################################################################
   # Survey Help
   ###########################################################################
 
   - key: features.features_intro
-    t: >
-      Welcome to the survey! This first part is all about figuring out 
-      which **features** of the JavaScript language you know about. 
-      And if you know about something but haven't yet used it, that's fine too!
+    t: アンケートへようこそ！1つ目のパートでは、JavaScriptの**機能**についてどれだけ知っているかを把握することが目的です。まだ使ったことがないけれど知っているものでも大丈夫です！
 
   - key: tools.tools_intro
-    t: >
-      The next couple sections focus on the **libraries** and **frameworks** that make up 
-      the JavaScript ecosystem. Let us know what you're excited about!
+    t: 次のいくつかのセクションでは、JavaScriptのエコシステムを構成する**ライブラリ**と**フレームワーク**に焦点を当てます。あなたが何に興奮しているか教えてください！
 
   ###########################################################################
   # Options
@@ -245,50 +240,50 @@ translations:
     aliasFor: options.js_pain_points.date_management.description
 
   - key: options.top_js_pain_points.performance
-    t: Performance
+    t: パフォーマンス
   - key: options.top_js_pain_points.performance.description
-    t: Writing performant and efficient JavaScript code
+    t: 高いパフォーマンスで効率的なJavaScriptコードを書く
 
   - key: options.top_js_pain_points.build_tools
-    t: Build Tools
+    t: ビルドツール
   - key: options.top_js_pain_points.build_tools.description
-    t: Managing tooling to bundle your code
+    t: コードのバンドルをするツールの管理
 
   - key: options.top_js_pain_points.typing
-    t: Typing
+    t: 型付け
   - key: options.top_js_pain_points.typing.description
-    t: Managing and maintaining types
+    t: 型の保守と管理
 
   - key: options.top_js_pain_points.build_tools
-    t: Build Tools
+    t: ビルドツール
   - key: options.top_js_pain_points.typing
-    t: Typing
+    t: 型付け
   - key: options.top_js_pain_points.typescript
     t: TypeScript
   - key: options.top_js_pain_points.esm_cjs
-    t: ESM vs CJS
+    t: ESM対CJS
   - key: options.top_js_pain_points.testing
-    t: Testing
+    t: テスト
   - key: options.top_js_pain_points.performance
-    t: Performance
+    t: パフォーマンス
   - key: options.top_js_pain_points.too_many_choices
-    t: Too Many Choices
+    t: 多すぎる選択肢
   - key: options.top_js_pain_points.react
     t: React
   - key: options.top_js_pain_points.bundlers
-    t: Bundlers
+    t: バンドラー
   - key: options.top_js_pain_points.complexity
-    t: Complexity
+    t: 複雑さ
   - key: options.top_js_pain_points.standard_library
-    t: Standard Library
+    t: 標準ライブラリ
   - key: options.top_js_pain_points.tooling
-    t: Tooling
+    t: ツール
   - key: options.top_js_pain_points.dependencies
-    t: Dependencies
+    t: 依存関係
   - key: options.top_js_pain_points.security
-    t: Security
+    t: セキュリティ
   - key: options.top_js_pain_points.slow
-    t: Slowness
+    t: 遅さ
 
   # JS missing features
   - key: options.currently_missing_from_js.static_typing
@@ -384,25 +379,25 @@ translations:
 
   # What do you use JS for?
   - key: options.what_do_you_use_js_for.frontend_development
-    t: Frontend Development
+    t: フロントエンド開発
   - key: options.what_do_you_use_js_for.backend_development
-    t: Backend Development
+    t: バックエンド開発
   - key: options.what_do_you_use_js_for.data_analysis
-    t: Data Analysis
+    t: データ分析
   - key: options.what_do_you_use_js_for.machine_learning
-    t: Machine Learning
+    t: 機械学習
   - key: options.what_do_you_use_js_for.desktop_apps
-    t: Desktop Apps
+    t: デスクトップアプリ開発
   - key: options.what_do_you_use_js_for.mobile_apps
-    t: Mobile Apps
+    t: モバイルアプリ開発
   - key: options.what_do_you_use_js_for.embedded_apps
-    t: Embedded Apps
+    t: 組み込みアプリ開発
   - key: options.what_do_you_use_js_for.game_development
-    t: Game Development
+    t: ゲーム開発
   - key: options.what_do_you_use_js_for.data_visualization
-    t: Data Visualization
+    t: データ可視化
   - key: options.what_do_you_use_js_for.graphics_animation
-    t: Graphics & Animation
+    t: グラフィックス＆アニメーション
 
   - key: options.what_do_you_use_js_for.scripting
     t: Scripting
@@ -428,64 +423,64 @@ translations:
   # JS App Patterns
 
   - key: options.js_app_patterns.single_page_app
-    t: Single Page Application (SPA)
+    t: シングルページアプリケーション（SPA）
   - key: options.js_app_patterns.single_page_app.description
-    t: Apps that run entirely in the browser
+    t: ほとんどがブラウザ上（クライアントサイド）で動作するアプリケーション
   - key: options.js_app_patterns.multiple_page_app
-    t: Multi-Page Application (MPA)
+    t: マルチページアプリケーション（MPA）
   - key: options.js_app_patterns.multiple_page_app.description
-    t: Apps that run entirely on the server, with minimal client-side dynamic behavior
+    t: ほとんどがサーバーサイドで動作し、クライアントサイドの動的な振る舞いが最小限であるアプリケーション
   - key: options.js_app_patterns.static_site_generation
-    t: Static Site Generation (SSG)
+    t: 静的サイト生成（SSG）
   - key: options.js_app_patterns.static_site_generation.description
-    t: Static content pre-rendered at build time, with or without a client-side dynamic element
+    t: ビルド時に静的コンテンツが事前に生成され、クライアントサイドの動的生成はあったりなかったりする手法
   - key: options.js_app_patterns.server_side_rendering
-    t: Server-Side Rendering (SSR)
+    t: サーバーサイドレンダリング（SSR）
   - key: options.js_app_patterns.server_side_rendering.description
-    t: Dynamically rendering HTML content on the server on request, before rehydrating it on the client
+    t: リクエストに応じてサーバー上でHTMLコンテンツを動的にレンダリングし、その後クライアント上で全体をハイドレーションする手法
   - key: options.js_app_patterns.partial_hydration
-    t: Partial Hydration
+    t: 部分的なハイドレーション（Partial Hydration）
   - key: options.js_app_patterns.partial_hydration.description
-    t: Only hydrating some of your components on the client (e.g. React Server Components)
+    t: 特定のコンポーネントのみをハイドレーションする手法（例：React Server Components）
   - key: options.js_app_patterns.progressive_rehydration
-    t: Progressive Hydration
+    t: プログレッシブハイドレーション（Progressive Hydration）
   - key: options.js_app_patterns.progressive_rehydration.description
-    t: Controlling the order of component hydration on the client
+    t: ハイドレーションするコンポーネントの順番を制御する手法
   - key: options.js_app_patterns.islands_architecture
-    t: Islands Architecture
+    t: アイランドアーキテクチャ（Islands Architecture）
   - key: options.js_app_patterns.islands_architecture.description
-    t: Isolated islands of dynamic behavior with multiple entry points in an otherwise static site (Astro, Eleventy)
+    t: 静的サイト内に動的な振る舞いをする孤立した島のような部分を複数組み合わせて作るアーキテクチャ（例：Astro、Eleventy）
   - key: options.js_app_patterns.progressive_enhancement
-    t: Progressive Enhancement
+    t: プログレッシブエンハンスメント（Progressive Enhancement）
   - key: options.js_app_patterns.progressive_enhancement.description
-    t: Making sure an app is functional even without JavaScript
+    t: JavaScriptが無効でもアプリケーションが最低限機能するように作る戦略
   - key: options.js_app_patterns.incremental_static_generation
-    t: Incremental Static Generation
+    t: インクリメンタル静的生成（Incremental Static Generation）
   - key: options.js_app_patterns.incremental_static_generation.description
-    t: Being able to dynamically augment or modify a static site even after the initial build (Next.js ISR & on-demand revalidation, Gatsby DSG)
+    t: 初回のビルド後も静的サイトを動的に更新、変更可能にする手法（Next.jsのISR & on-demand revalidation、GatsbyのDSG）
   - key: options.js_app_patterns.streaming_ssr
-    t: Streaming SSR
+    t: ストリーミングサーバサイドレンダリング（Streaming SSR）
   - key: options.js_app_patterns.streaming_ssr.description
-    t: Breaking down server-rendered content in smaller streamed chunks
+    t: サーバーサイドでレンダリングされたコンテンツを小さなストリーミングチャンク分割して扱う手法
   - key: options.js_app_patterns.resumability
-    t: Resumability
+    t: 再開可能性（Resumability）
   - key: options.js_app_patterns.resumability.description
-    t: Serializing framework state on the server so the client can resume execution with no duplicated code execution.
+    t: サーバ上でフレームワークの状態をシリアライズすることで、クライアントがコードの重複実行なしで再開できるようにする手法
   - key: options.js_app_patterns.edge_rendering
-    t: Edge Rendering
+    t: エッジレンダリング（Edge Rendering）
   - key: options.js_app_patterns.edge_rendering.description
-    t: Altering rendered HTML at the edge before sending it on to the client
+    t: クライアントに送信する前に、エッジでレンダリングされたHTMLを変更する手法
   - key: options.js_app_patterns.partial_prerendering
-    t: Partial Prerendering
+    t: パーシャルプリレンダリング（Partial Prerendering）
   - key: options.js_app_patterns.partial_prerendering.description
-    t: Render a route with a static loading shell, while keeping some parts dynamic
+    t: ルート内で一部を動的に保ちつつ、静的な部分はシェルとして事前にレンダリングする手法
 
   - key: options.js_app_patterns.micro_frontend
-    t: Micro Frontend
+    t: マイクロフロントエンド
   - key: options.js_app_patterns.domain_driven_design
-    t: Domain-Driven Design
+    t: ドメイン駆動デザイン
   - key: options.js_app_patterns.serverless
-    t: Serverless
+    t: サーバーレス
   - key: options.js_app_patterns.pespa
     t: PESPA
 
@@ -521,9 +516,9 @@ translations:
   - key: features.arrow_functions
     t: アロー関数（arrow functions）
   - key: features.nullish_coalescing
-    t: Nullish Coalescing
+    t: Null 合体演算子（Nullish Coalescing）
   - key: features.optional_chaining
-    t: Optional Chaining
+    t: オプショナルチェーン（Optional Chaining）
   - key: features.private_fields
     t: プライベートフィールド
 
@@ -542,39 +537,39 @@ translations:
     t: Dynamic Import
 
   - key: features.syntax_features
-    t: Syntax Features
+    t: 構文機能
   - key: features.syntax_features.question
-    t: Which of these syntax features have you used?
+    t: どの構文機能を使ったことがありますか？
 
   - key: features.string_features
-    t: String Features
+    t: 文字列の機能
   - key: features.string_features.question
-    t: Which of these String features have you used?
+    t: どの文字列機能を使ったことがありますか？
 
   - key: features.array_features
-    t: Array Features
+    t: 配列の機能
   - key: features.array_features.question
-    t: Which of these Array features have you used?
+    t: どの配列機能を使ったことがありますか？
 
   - key: features.async_features
-    t: Async Features
+    t: 非同期の機能
   - key: features.async_features.question
-    t: Which of these async features have you used?
+    t: どの非同期機能を使ったことがありますか？
 
   - key: features.browser_api_features
-    t: Browser APIs
+    t: ブラウザのAPI
   - key: features.browser_api_features.question
-    t: Which of these browser APIs have you used?
+    t: どのブラウザAPIを使ったことがありますか？
 
   - key: features.language_pain_points
-    t: Language Pain Points
+    t: 言語のつらいところ
   - key: features.language_pain_points.question
-    t: What are your main pain points regarding the JavaScript language?
+    t: JavaScript言語に関して、つらいと感じるところは何ですか？
 
   - key: features.browser_apis_pain_points
-    t: Browser APIs Pain Points
+    t: ブラウザAPIのつらいところ
   - key: features.browser_apis_pain_points.question
-    t: What are your main pain points regarding browser APIs?
+    t: ブラウザAPIに関して、つらいと感じるところは何ですか？
 
   # patterns
   - key: patterns.object_oriented_programming
@@ -608,102 +603,100 @@ translations:
     t: これは[Angular](https://angular.io/)についてで、非推奨になった[AngularJS](https://angularjs.org/)のものではないことに注意してください。
 
   - key: tools.best_of_js_projects.note
-    t: >
-      Libraries are loaded from [Best of JS](https://bestofjs.org/). 
-      If a project is missing, you can [submit it here](https://github.com/michaelrambeau/bestofjs/issues/new?template=add-a-project-to-best-of-javascript.md).
+    t: ライブラリは[Best of JS](https://bestofjs.org/)から読み込まれます。プロジェクトが見つからない場合は、[GitHubのIssue](https://github.com/michaelrambeau/bestofjs/issues/new?template=add-a-project-to-best-of-javascript.md)を立てることができます。
 
   # front-end frameworks
   - key: tools.front_end_frameworks_happiness
-    t: Front-end Frameworks Happiness
+    t: フロントエンドフレームワークの満足度
   - key: tools.front_end_frameworks_happiness.question
-    t: How happy are you with the current state of front-end frameworks?
+    t: フロントエンドフレームワークの現状にどのくらい満足していますか？
 
   - key: tools.front_end_frameworks_pain_points
-    t: Front-end Frameworks Pain Points
+    t: フロントエンドフレームワークのつらいところ
   - key: tools.front_end_frameworks_pain_points.question
-    t: What pain points have you encountered when using front-end frameworks?
+    t: フロントエンドフレームワークを使うときに、つらいと感じるところは何ですか？
 
   # meta-frameworks
 
   - key: tools.meta_frameworks_happiness
-    t: Meta-Frameworks Happiness
+    t: メタフレームワークの満足度
   - key: tools.meta_frameworks_happiness.question
-    t: How happy are you with the current state of meta-frameworks?
+    t: メタフレームワークの現状にどのくらい満足していますか？
 
   - key: tools.meta_frameworks_pain_points
-    t: Meta-Frameworks Pain Points
+    t: メタフレームワークのつらいところ
   - key: tools.meta_frameworks_pain_points.question
-    t: What pain points have you encountered when using meta-frameworks?
+    t: メタフレームワークを使うときに、つらいと感じるところは何ですか？
 
   # testing
 
   - key: tools.testing_happiness
-    t: Testing Happiness
+    t: テストの満足度
   - key: tools.testing_happiness.question
-    t: How happy are you with the current state of testing tools?
+    t: テストツールの現状にどのくらい満足していますか？
 
   - key: tools.testing_pain_points
-    t: Testing Pain Points
+    t: テストのつらいところ
   - key: tools.testing_pain_points.question
-    t: What pain points have you encountered when using testing tools?
+    t: テストツールを使うときに、つらいと感じるところは何ですか？
 
   # mobile & desktop
 
   - key: tools.mobile_desktop_happiness
-    t: Mobile & Desktop Happiness
+    t: モバイル＆デスクトップ開発の満足度
   - key: tools.mobile_desktop_happiness.question
-    t: How happy are you with the current state of mobile & desktop tools?
+    t: モバイル＆デスクトップアプリ開発の現状にどのくらい満足していますか？
 
   - key: tools.mobile_desktop_pain_points
-    t: Mobile & Desktop Pain Points
+    t: モバイル＆デスクトップ開発のつらいところ
   - key: tools.mobile_desktop_pain_points.question
-    t: What pain points have you encountered when using JavaScript to build mobile & desktop apps?
+    t: モバイル＆デスクトップアプリ開発をするときに、つらいと感じるところは何ですか？
 
   # build tools
 
   - key: tools.build_tools_happiness
-    t: Build Tools Happiness
+    t: ビルドツールの満足度
   - key: tools.build_tools_happiness.question
-    t: How happy are you with the current state of build tools?
+    t: ビルドツールの現状にどのくらい満足していますか？
 
   - key: tools.build_tools_pain_points
-    t: Build Tools Pain Points
+    t: ビルドツールのつらいところ
   - key: tools.build_tools_pain_points.question
-    t: What pain points have you encountered when using build tools?
+    t: ビルドツールを使うときに、つらいと感じるところは何ですか？
 
   # monorepo tools
 
   - key: tools.monorepo_tools_happiness
-    t: Monorepo Happiness
+    t: モノレポツールの満足度
   - key: tools.monorepo_tools_happiness.question
-    t: How happy are you with the current state of monorepo tools?
+    t: モノレポツールの現状にどのくらい満足していますか？
 
   - key: tools.monorepo_tools_pain_points
-    t: Monorepo Pain Points
+    t: モノレポツールのつらいところ
   - key: tools.monorepo_tools_pain_points.question
-    t: What pain points have you encountered when using monorepo tools?
+    t: モノレポツールを使うときに、つらいと感じるところは何ですか？
 
   ###########################################################################
   # Other Tools
   ###########################################################################
 
   - key: tools_others.libraries
-    t: Libraries
+    t: ライブラリ
   - key: tools_others.libraries.description
-    t: Which libraries do you regularly use?
+    t: 普段どのライブラリを使っていますか？
   - key: tools_others.libraries.others
-    t: Other Libraries
+    t: そのほかのライブラリ
   - key: tools_others.libraries.others.description
-    t: Other answers (freeform field).
+    t: そのほかの回答（自由入力欄）
 
   - key: tools_others.text_editors
-    t: Text Editors
+    t: テキストエディタ
   - key: tools_others.text_editors.description
-    t: Which text editor(s) do you regularly use?
+    t: 普段どのテキストエディタを使っていますか？
   - key: tools_others.text_editors.others
-    t: Other Text Editors
+    t: そのほかのテキストエディタ
   - key: tools_others.text_editors.others.description
-    t: Other answers (freeform field).
+    t: そのほかの回答（自由入力欄）
 
   - key: tools_others.utilities
     t: Utilities
@@ -712,7 +705,7 @@ translations:
   - key: tools_others.utilities.others
     t: Other Utilities
   - key: tools_others.utilities.others.description
-    t: Other utilities (freeform field).
+    t: Other utilities（自由入力欄）
 
   - key: tools_others.browsers
     t: Browsers
@@ -721,7 +714,7 @@ translations:
   - key: tools_others.browsers.others
     t: Other Browsers
   - key: tools_others.browsers.others.description
-    t: Other answers (freeform field).
+    t: そのほかの回答（自由入力欄）
 
   - key: tools_others.build_tools
     t: Build Tools
@@ -730,7 +723,7 @@ translations:
   - key: tools_others.build_tools.others
     t: Other Build Tools
   - key: tools_others.build_tools.others.description
-    t: Other answers (freeform field).
+    t: そのほかの回答（自由入力欄）
 
   - key: tools_others.non_js_languages
     t: Non-JavaScript Languages
@@ -739,7 +732,7 @@ translations:
   - key: tools_others.non_js_languages.others
     t: Other Languages
   - key: tools_others.non_js_languages.others.description
-    t: Other answers (freeform field).
+    t: そのほかの回答（自由入力欄）
 
   - key: tools_others.javascript_flavors
     t: JavaScript Flavors
@@ -748,7 +741,7 @@ translations:
   - key: tools_others.javascript_flavors.others
     t: Other JavaScript Flavors
   - key: tools_others.javascript_flavors.others.description
-    t: Other answers (freeform field).
+    t: そのほかの回答（自由入力欄）
 
   - key: tools_others.runtimes
     t: JavaScriptランタイム
@@ -795,18 +788,18 @@ translations:
     t: Other Data Visualization Libraries
 
   - key: tools_others.graphics_animation
-    t: Graphics & Animations
+    t: グラフィックス＆アニメーション
   - key: tools_others.graphics_animation.description
-    t: Libraries dedicated to graphics and animation.
+    t: グラフィックスとアニメーションに特化したライブラリ
   - key: tools_others.graphics_animation.others
-    t: Other Graphics & Animations Libraries
+    t: そのほかのグラフィックス＆アニメーションライブラリ
 
   - key: tools_others.data_fetching
-    t: Data Fetching
+    t: データ取得
   - key: tools_others.data_fetching.description
-    t: Libraries that manage data fetching and caching.
+    t: データ取得とキャッシュ処理に特化したライブラリ
   - key: tools_others.data_fetching.others
-    t: Other Data Fetching Libraries
+    t: そのほかのデータ取得ライブラリ
 
   - key: other_tools.libraries
     aliasFor: tools_others.libraries
@@ -944,65 +937,66 @@ translations:
     aliasFor: tools_others.backend_frameworks.others
 
   - key: other_tools.ai_tools
-    t: AI Tools
+    t: AIツール
   - key: other_tools.ai_tools.question
-    t: Which of these AI tools do you regularly use to help you write code?
+    t: コードを書くために、普段使っているAIツールはありますか？
 
   - key: other_tools.hosting
-    t: Hosting Services
+    t: サービスのホスティング
   - key: other_tools.hosting.question
-    t: Which of these services have you used to host JavaScript apps?
+    t: JavaScriptアプリケーションをホスティングするためのに使ったことがあるツールはありますか？
 
   ###########################################################################
   # Usage
   ###########################################################################
 
   - key: usage.js_app_patterns
-    t: Application Patterns
+    t: アプリケーションパターン
   - key: usage.js_app_patterns.question
-    t: Which of the following architecture and rendering patterns have you used **in the last year**?
+    t: >
+      **過去1年間**で、どのアーキテクチャやレンダリングパターンを使用しましたか？
   - key: usage.js_app_patterns.others
-    t: Other App Patterns
+    t: その他のアプリケーションパターン
 
   - key: usage.what_do_you_use_js_for
-    t: JavaScript Usage
+    t: JavaScriptの使用状況
   - key: usage.what_do_you_use_js_for.question
-    t: What do you use JavaScript for?
+    t: どのような目的でJavaScriptを使っていますか？
   - key: usage.what_do_you_use_js_for.others
-    t: Other JavaScript Use Cases
+    t: そのほかのJavaScriptユースケース
 
   - key: usage.js_ts_balance
-    t: JavaScript/TypeScript Balance
+    t: JavaScriptとTypeScriptのバランス
   - key: usage.js_ts_balance.question
-    t: How do you divide your time between writing JavaScript and TypeScript code?
+    t: どのくらいの割合でJavaScriptとTypeScriptを書いていますか？
 
   - key: tools_others.edge_runtimes
-    t: JavaScript Edge/Serverless Runtimes
+    t: JavaScriptのエッジ/サーバーレスランタイム
   - key: tools_others.edge_runtimes.question
-    t: Which edge or serverless runtimes do you regularly use?
+    t: いつもどのエッジ/サーバーレスランタイムを使っていますか？
   - key: tools_others.edge_runtimes.others
-    t: Other Edge Runtimes
+    t: そのほかのエッジランタイム
   - key: other_tools.edge_runtimes
     aliasFor: tools_others.edge_runtimes
   - key: other_tools.edge_runtimes.description
     aliasFor: tools_others.edge_runtimes.question
 
   - key: usage.usage_type
-    t: JavaScript Usage
+    t: JavaScriptの使用状況
   - key: usage.usage_type.question
-    t: In what context do you primarily use JavaScript?
+    t: 主にどのようなコンテキストでJavaScriptを使っていますか？
   - key: usage.usage_type.others
-    t: Other Usages
+    t: そのほかの使用状況
 
   - key: opinions.pick_of_the_year
-    t: Your “Pick of the Year”
+    t: 今年のイチオシ
   - key: opinions.pick_of_the_year.description
-    t: The name of a feature, library, website, person, etc. you want to highlight this year.
+    t: あなたが今年ハイライトしたい機能、ライブラリ、ウェブサイト、人などの名前
 
   - key: usage.industry_sector_js
     aliasFor: usage.industry_sector
   - key: usage.industry_sector_js.question
-    t: Which industry sector(s) are you using JavaScript in?
+    t: あなたがJavaScriptを使用している業界は何ですか？
   - key: usage.industry_sector_js.others
     aliasFor: usage.industry_sector.others
 
@@ -1046,7 +1040,7 @@ translations:
   - key: happiness.monorepo_tools
     t: モノレポツールの現状に満足していますか？
   - key: happiness.rendering_frameworks
-    t: How happy are you with the state of rendering frameworks?
+    t: レンダリングフレームワークの現状に満足していますか？
 
   - key: happiness.state_of_the_web
     t: ウェブ技術の現状に満足していますか？
@@ -1063,7 +1057,7 @@ translations:
   - key: usage.top_js_pain_points
     aliasFor: opinions.js_pain_points
   - key: usage.top_js_pain_points.question
-    t: What aspects of JavaScript do you struggle with the most?
+    t: JavaScriptのどこに一番苦労していますか？
 
   - key: opinions.js_pain_points
     t: JavaScriptのつらいところ
@@ -1075,7 +1069,7 @@ translations:
   - key: opinions.top_js_pain_points
     aliasFor: opinions.js_pain_points
   - key: opinions.top_js_pain_points.description
-    t: Pick the top 3 aspects of JavaScript you struggle with the most.
+    t: JavaScriptにおいてあなたが苦労している要素を3つ選んでください。
   - key: opinions_others.top_js_pain_points.others
     aliasFor: opinions_others.js_pain_points.others
   - key: opinions.top_js_pain_points.others
@@ -1084,7 +1078,7 @@ translations:
   # Missing Features
 
   - key: usage.top_currently_missing_from_js
-    t: Missing Features
+    t: 欠けている機能
   - key: usage.top_currently_missing_from_js.question
     aliasFor: opinions.currently_missing_from_js
 
@@ -1098,7 +1092,7 @@ translations:
   - key: opinions.top_currently_missing_from_js
     aliasFor: opinions.currently_missing_from_js
   - key: opinions.top_currently_missing_from_js.description
-    t: Pick the top 3 features you'd most like to be able to use in JavaScript today.
+    t: JavaScriptで今すぐに利用したい機能を3つ選んでください。
   - key: opinions_others.top_currently_missing_from_js.others
     aliasFor: opinions_others.currently_missing_from_js.others
   - key: opinions.top_currently_missing_from_js.others

--- a/state_of_js.yml
+++ b/state_of_js.yml
@@ -108,7 +108,7 @@ translations:
   - key: sections.monorepo_tools.title
     t: モノレポのツール
   - key: sections.monorepo_tools.description
-    t: JavaScriptモノレポの管理に使うツール
+    t: モノレポの管理に使うツール
 
   - key: sections.tools_others.title
     t: そのほかのツール
@@ -118,7 +118,7 @@ translations:
   - key: sections.other_tools.title
     t: そのほかのツール
   - key: sections.other_tools.description
-    t: 以下のツールや技術について、普段使っているものにチェックをつけてください
+    t: 各ツールや技術について、普段使っているものにチェックをつけてください
 
   - key: sections.resources_js.title
     t: リソース
@@ -1045,12 +1045,12 @@ translations:
   - key: happiness.state_of_the_web
     t: ウェブ技術の現状に満足していますか？
   - key: happiness.state_of_the_web.question
-    t: How happy are you with the general state of web technologies?
+    t: ウェブ技術全般の現状ついてどれくらい満足していますか？
 
   - key: happiness.state_of_js
     t: JavaScriptの現状に満足していますか？
   - key: happiness.state_of_js.question
-    t: How happy are you with the general state of JavaScript?
+    t: JavaScript全般の現状ついてどれくらい満足していますか？
 
   # Pain Points
 

--- a/surveys.yml
+++ b/surveys.yml
@@ -1,73 +1,652 @@
 locale: ja-JP
 translations:
-    ###########################################################################
-    # General
-    ###########################################################################
+  ###########################################################################
+  # General
+  ###########################################################################
 
-    - key: general.no_preview_surveys
-      t: 表示できるアンケートはありません
-    - key: general.global_nav
-      t: グローバル
+  - key: general.title
+    t: Devographics Surveys
+  - key: general.description
+    t: The State of JavaScript, State of CSS, State of HTML, and other developer surveys.
 
-    ###########################################################################
-    # FAQ
-    ###########################################################################
+  - key: general.no_preview_surveys
+    t: 表示できるアンケートはありません
+  - key: general.global_nav
+    t: グローバル
+  - key: general.survey_status_preview
+    t: Preview
+  - key: general.survey_status_open
+    t: Open
+  - key: general.survey_status_closed
+    t: Closed
+  - key: general.survey_status_hidden
+    t: Hidden
 
-    - key: general.faq
-      t: FAQ
-    - key: faq.create_account
-      t: アカウントを作る必要はありますか？
-    - key: faq.create_account.description
-      t: 重複回答を避けるため、またあなたの回答データを保存するため、そして結果が公開されたときにあなたに伝えられるよう、アカウントの作成をお願いしています。
-    - key: faq.anonymous_survey
-      t: 匿名での回答はできますか？
-    - key: faq.anonymous_survey.description
-      t: はい。偽のメールアドレス（something@example.com）や、個人を特定しないメールアドレスを利用すれば可能です。アドレスが分かってさえいれば、回答を保持できます。
-    - key: faq.questions_required
-      t: 全部の質問に答えないといけませんか？
-    - key: faq.questions_required.description
-      t: すべての回答は任意になっているので、飛ばすこともできます。
-    - key: faq.data_published
-      t: 私のデータは公開されますか？
-    - key: faq.data_published.description
-      t: はい。基本的にすべてのデータが公開されますが、個人を特定可能な情報（メールアドレス、ユーザー名、IDなど）は省かれます。
-    - key: faq.survey_design
-      t: 設問はどうやって作られましたか？
-    - key: faq.survey_design.description
-      t: アンケートの設問はコミュニティからフィードバックや、エキスパートのレビューを経て作られています。[詳細はこちら](https://dev.to/sachagreif/how-the-state-of-js-css-surveys-are-run-4lnb)
-    - key: faq.results_released
-      t: 結果はいつ公開されますか？
-    - key: faq.results_released.description
-      t: 基本的にはアンケート期間終了後、数週間で公開しています。
-    - key: faq.survey_deadline
-      t: 回答期限はいつまでですか？
-    - key: faq.survey_deadline.description
-      t: このアンケートは {date} まで実施しています。
-    - key: faq.team
-      t: このアンケートは誰が行っていますか？
-    - key: faq.team.description
-      t: アンケートは[私](http://sachagreif.com)を中心に、コントリビュータや翻訳者、ボランティアの協力のもと行っています。
+  - key: general.pick_up_to
+    t: Pick up to {limit} items.
 
-    ###########################################################################
-    # Form Controls
-    ###########################################################################
+  - key: general.privacy_policy
+    t: Privacy Policy
+  - key: general.privacy_policy.description
+    t: >
+      ### 1. Data Collection
 
-    - key: bracket.vs
-      t: VS
-    - key: bracket.start_over
-      t: 最初からやり直す
-    - key: bracket.winner
-      t: 勝者：
-    - key: bracket.round
-      t: ラウンド
-    - key: bracket.empty_bracket
-      t: 結果待ち（前のラウンドを完了してください）
-    - key: bracket.result
-      t: 結果
-    - key: bracket.cancel
-      t: キャンセル
+      In addition to the data collected through a survey's questions, we collect your device, browser, OS, browser version, and referrer.
+
+      Note that all questions are entirely optional, and we never link any identifiable information (such as email addresses) to your survey answers.
+
+      ### 2. Email Collection
+
+      We may optionally collect your email to:
 
 
-    ###########################################################################
-    # Demographics (About You/User Info)
-    ###########################################################################
+      1. Generate a magic log-in link, after which we discard your email and only keep a one-way hash in our user database.
+
+      2. Contact you once survey results are available, as well as when we launch future editions of a survey and for infrequent announcements. You can unsubscribe from our mailing list at any time, and your email is discarded from our records once it is sent to our email newsletter provider.
+
+      3. Send you a recap list of features or tools you want to learn more about. We will discard your address once the email has been sent out through our transactional email provider.
+
+
+      When we do collect your email address, it is never linked to your responses for a survey, or to your user account.
+
+      ### 3. Cookies
+
+      We set a log-in cookie, and our hosting provider (Vercel) may also sets its own cookie. We do not set any other cookie or use client-side analytics or ads.
+
+      ### 4. Data Use
+
+      We process the data and then use it to publish reports. We also make the entire dataset publicly available.
+
+      ### 5. Data/Account Deletion
+
+      You can email us at [hello@stateofjs.com](mailto:hello@stateofjs.com) if you'd like us to delete all or part of your data.
+
+  ###########################################################################
+  # Other UI Strings
+  ###########################################################################
+
+  - key: textlist.placeholder
+    t: Item {index}…
+
+  - key: feature.unimplemented
+    t: No browser implementation yet
+
+  - key: general.skip_question
+    t: Skip
+
+  - key: general.unskip_question
+    t: Answer Question
+
+  - key: general.skip_question.description
+    t: Skip question and mark it as completed
+
+  - key: general.unskip_question.description
+    t: Unskip question and answer it
+
+  - key: years.less_than_one_year
+    t: Less than one year
+
+  - key: years.years
+    t: years
+
+  - key: likert.option.0
+    t: Very Unhappy
+  - key: likert.option.1
+    t: Unhappy
+  - key: likert.option.2
+    t: Neutral
+  - key: likert.option.3
+    t: Happy
+  - key: likert.option.4
+    t: Very Happy
+
+  - key: general.numeric_input.invalid_input
+    t: Please make sure you enter a valid number.
+
+  ###########################################################################
+  # Errors & Messages
+  ###########################################################################
+
+  - key: error.duplicate_response
+    t: Sorry, you already have a session in progress for this survey.
+
+  - key: error.report_issue
+    t: Report issue
+
+  - key: success.data_saved
+    t: Data Saved
+  - key: success.data_saved.description
+    t: Your data has been saved.
+
+  ###########################################################################
+  # Accounts
+  ###########################################################################
+
+  - key: accounts.create_account
+    t: Continue with Account
+  - key: accounts.create_account.description
+    t: Having an account lets you **access your own data in the future** and be notified when survey results are published.
+  - key: accounts.create_account.note
+    t: If you **already have an account** we will send you a magic log-in link by email.
+  - key: accounts.create_account.action
+    t: Continue with Account
+  - key: accounts.your_email
+    t: Your Email
+
+  - key: accounts.upgrade_account.action
+    t: Upgrade your account
+  - key: accounts.upgrade_account.description
+    t: Upgrading your account with an email address will let you access your survey response after you end your session.
+
+  - key: accounts.continue_as_guest
+    t: Continue as Guest
+  - key: accounts.continue_as_guest.description
+    t: Taking the survey anonymously means you **won't be able to access your data again** after you end your session.
+  - key: accounts.continue_as_guest.action
+    t: Continue as Guest
+
+  - key: accounts.magic_link.no_email
+    t: Please enter your email
+  - key: accounts.magic_link.success
+    t: Check your inbox! We sent you a magic link, just click it to confirm your account and log in.
+    # Open known mail provider directly in browser with the right search params
+  - key: accounts.magic_link.browser
+    t: <a href="{link}">Click to open your inbox.</a>
+
+  ###########################################################################
+  # FAQ
+  ###########################################################################
+
+  - key: general.faq
+    t: FAQ
+  - key: faq.create_account
+    t: アカウントを作る必要はありますか？
+  - key: faq.create_account.description
+    t: 重複回答を避けるため、またあなたの回答データを保存するため、そして結果が公開されたときにあなたに伝えられるよう、アカウントの作成をお願いしています。
+  - key: faq.anonymous_survey
+    t: 匿名での回答はできますか？
+  - key: faq.anonymous_survey.description
+    t: はい。偽のメールアドレス（something@example.com）や、個人を特定しないメールアドレスを利用すれば可能です。アドレスが分かってさえいれば、回答を保持できます。
+  - key: faq.questions_required
+    t: 全部の質問に答えないといけませんか？
+  - key: faq.questions_required.description
+    t: すべての回答は任意になっているので、飛ばすこともできます。
+  - key: faq.data_published
+    t: 私のデータは公開されますか？
+  - key: faq.data_published.description
+    t: はい。基本的にすべてのデータが公開されますが、個人を特定可能な情報（メールアドレス、ユーザー名、IDなど）は省かれます。
+  - key: faq.survey_design
+    t: 設問はどうやって作られましたか？
+  - key: faq.survey_design.description
+    t: アンケートの設問はコミュニティからフィードバックや、エキスパートのレビューを経て作られています。[詳細はこちら](https://dev.to/sachagreif/how-the-state-of-js-css-surveys-are-run-4lnb)
+  - key: faq.results_released
+    t: 結果はいつ公開されますか？
+  - key: faq.results_released.description
+    t: 基本的にはアンケート期間終了後、数週間で公開しています。
+  - key: faq.survey_deadline
+    t: 回答期限はいつまでですか？
+  - key: faq.survey_deadline.description
+    t: このアンケートは {date} まで実施しています。
+  - key: faq.team
+    t: このアンケートは誰が行っていますか？
+  - key: faq.team.description
+    t: アンケートは[私](http://sachagreif.com)を中心に、コントリビュータや翻訳者、ボランティアの協力のもと行っています。
+
+  ###########################################################################
+  # Form Controls
+  ###########################################################################
+
+  - key: bracket.vs
+    t: VS
+  - key: bracket.start_over
+    t: 最初からやり直す
+  - key: bracket.winner
+    t: 勝者：
+  - key: bracket.round
+    t: ラウンド
+  - key: bracket.empty_bracket
+    t: 結果待ち（前のラウンドを完了してください）
+  - key: bracket.result
+    t: 結果
+  - key: bracket.cancel
+    t: キャンセル
+
+  - key: experience.leave_comment
+    t: Leave a Comment (optional)
+  - key: experience.leave_comment_short
+    t: Leave a Comment
+  - key: experience.tell_us_more
+    t: "You answered “{response}”. Tell us more about your choice:"
+  - key: experience.tell_us_more_generic
+    t: "Tell us more about your answer:"
+  - key: experience.tell_us_more_no_value
+    t: "You didn't pick any response. Tell us why:"
+
+  ###########################################################################
+  # Response
+  ###########################################################################
+
+  - key: response.completion
+    t: "{completion}% completed"
+
+  - key: response.details
+    t: Started on {startedAt}, {completion}% completed.
+
+  ###########################################################################
+  # Reading List
+  ###########################################################################
+
+  - key: readinglist.prompt
+    t: >
+      You picked “{option}”. If you'd like to learn more about this feature at the end of the survey, you can click the "+" icon above to add it to your **reading list**.
+
+  - key: readinglist.add_to_list
+    t: Add to Your Reading List
+
+  - key: readinglist.remove_from_list
+    t: Remove from Reading List
+
+  - key: readinglist.added_to_list
+    t: Added “{label}” to your reading list.
+
+  - key: readinglist.title
+    t: Reading List
+
+  - key: readinglist.description
+    t: >
+      Save items here using the "+" button, and you'll get a list of links to learn more about them at the end of the survey.
+
+  - key: readinglist.empty
+    t: >
+      You don't have any items in your reading list.
+      Try going back to the survey and adding features or libraries you'd like
+      to learn more about using the "+" button.
+
+  - key: readinglist.results
+    t: >
+      Here are some resources to learn more about the items in your reading list:
+
+  - key: readinglist.homepage_link
+    t: Homepage
+
+  - key: readinglist.receive_copy
+    t: >
+      Enter your email to get a copy of your reading list straight in your inbox:
+  - key: readinglist.send_by_email
+    t: Send
+  - key: readinglist.email_sent
+    t: Thanks! Your reading list is on its way to your inbox.
+
+  ###########################################################################
+  # Score & Knowledge Ranks
+  ###########################################################################
+
+  - key: knowledge_rank.your_rank
+    t: "Your Rank:"
+  - key: knowledge_rank.rank1
+    t: Novice
+  - key: knowledge_rank.rank2
+    t: Apprentice
+  - key: knowledge_rank.rank3
+    t: Intermediate
+  - key: knowledge_rank.rank4
+    t: Expert
+  - key: knowledge_rank.rank5
+    t: Scholar
+  - key: knowledge_rank.rank6
+    t: Elite
+
+  ###########################################################################
+  # Survey-Specific Intros
+  ###########################################################################
+
+  - key: general.js2020.survey_intro
+    t: |
+      2020 has been a tough year for everyone, one that makes worrying about the
+      latest JavaScript frameworks seem pretty futile in comparison.
+
+      Still, the world has to move on, and so does JavaScript. And once again, with your help
+      we'll try to build a comprehensive picture of the ecosystem to find out a little bit more
+      about where it's going.
+
+  - key: general.css2021.survey_intro
+    t: |
+      Hey CSS, what have you been up to lately? Oh really, `@container`? Oh and
+      intrinsic sizing? And `@property` too?! Wow, you've been busy!
+
+      Even though the pandemic kept on making everybody's lives harder throughout 2021, somehow
+      dedicated contributors around the world managed to keep CSS moving forward.
+      And so once more it's time to survey the CSS ecosystem and figure out
+      where this is all going. And maybe learn about a few new things while you're at it!
+
+  - key: general.js2021.survey_intro
+    t: |
+      First the 2020 Olympics got pushed back to 2021,
+      and now the 2021 State of JavaScript survey is happening now, in 2022!
+
+      It's true: between work, family, and and all the turmoil in the world,
+      some things got disrupted a little.
+
+      But while the year may be off-by-one, we hope the data provided by the
+      survey itself will be just as informative and insightful as ever.
+      And don't worry, there will be another survey towards the end of this year to set things straight again!
+
+  - key: general.graphql2022.survey_intro
+    t: |
+      When GraphQL was first introduced it offered a radically new way to build APIs, with more control, more granularity, and more flexibility.
+
+      But that flexibility came at a price in the form of extra complexity, and a crop of frameworks, libraries, and services quickly appeared to help define better patterns and workflows.
+
+      Now, for the first time ever we're surveying the GraphQL community to figure out which of these many tools are the most popular, and which features are actually being used. With your help, let's see what GraphQL has been up to in 2022!
+
+  - key: general.css2022.survey_intro
+    t: |
+      CSS keeps progressing at an unprecedented rate. Luckily this year we got help from someone at the forefront of all these changes: [Lea Verou](https://lea.verou.me/) took the lead on selecting this year's questions, with a special focus on highlighting new and upcoming CSS features.
+
+      What's more, the survey results will also help browser vendors prioritize their roadmaps and work towards better compatibility between browsers.
+
+      With all this out of the way, let's see how CSS evolved in 2022!
+
+  - key: general.js2022.survey_intro
+    t: |
+      For the first time in a while, it feels like the status quo of the JavaScript ecosystem is being questioned.
+
+      Faster bundling with Vite, island architecture with Astro, resumability with Qwik… New entrants are challenging the old guard, and the result is a lot more excitement, but also
+      a lot more uncertainty.
+
+      So once more, let's try and figure out together where JavaScript is going, in 2022 and beyond.
+
+  - key: general.css2023.survey_intro
+    t: |
+      To help you keep up with `:has()`, `@container`, and all the other new CSS features, we're introducing a new feature of our own this year: the **Reading List**.
+
+      As you take the survey, you'll be able to bookmark any feature you want and learn more about it after you submit your answers.
+
+      This year [Chen Hui Jing](https://chenhuijing.com/) took the lead of the survey design process, building on the work done by [Lea Verou](https://lea.verou.me/) last year. And as usual, your feedback here will play a key role in helping browser vendors prioritize their roadmaps and work towards better compatibility between browsers.
+
+      With all this out of the way, let's see how CSS has evolved so far in 2023!
+
+  # Intro for actual survey page
+  - key: general.html2023.survey_intro
+    t: |
+      While web developers tend to focus on JavaScript and CSS, none of what we do would be possible without HTML acting as the foundation.
+
+      It has long seemed like HTML wasn't evolving, but things may be changing.
+      New elements like `<selectlist>` are on the horizon, cool new features like popovers,
+      and a swath of related browser APIs (Web Components, PWAs, etc.).
+
+      This year, [Lea Verou](https://lea.verou.me/) took on the formidable task of leading the design of this brand new survey, from content to UX and beyond.
+
+      Building on the success of [State of JS](http://stateofjs.com/) and [State of CSS](https://stateofcss.com/), we introduce **State of HTML**;
+      the last missing piece that completes the trilogy, so we can track the evolution of the web platform as a whole.
+
+      Benefits to you:
+      - Survey results are **used by browsers** and standards groups **for roadmap prioritization**.
+      Your responses can help get features you care about implemented, browser incompatibilities being prioritized, and gaps in the platform being addressed.
+      - Learn about new and upcoming features; add features to your reading list and get a list of resources at the end!
+      - Get a personalized knowledge score and see how you compare to other respondents
+
+      The survey will be open for 3 weeks, but responses entered **within the first 9 days (until October 1st)** will have a much higher impact on the Web,
+      as preliminary data will be used for certain prioritization efforts that have deadlines before then.
+
+  - key: general.react2023.survey_intro
+    t: |
+      As soon as React was first introduced, it was clear that it would become a big deal for the web. 
+
+      It was used to build Facebook after all, and despite this weird "JSX" thing, developers quickly adopted it. And what's even more impressive, the community stuck on through major changes such as function components and hooks. 
+
+      But it's now 10 years later and the newly-introduced React Server Components promise to be the biggest change since… well, since React itself!
+
+      Will the community follow along one more time? Or will developers jump ship to Svelte, Solid, or something else?
+
+      Let's find out together with the first ever State of React survey!
+
+  # JS 2023
+
+  - key: general.js2023.survey_intro
+    t: |
+      Between Astro, Vite, and Remix, 2022 kicked off a wave of JavaScript change that kept on growing in 2023 with Bun, Svelte 5, Tauri, and many others. 
+
+      But the –relatively speaking– old guard hasn't been standing still either, with Next.js and React leading the way with innovations such as Server Components and Server Actions. 
+
+      So after yet another busy year, it's now time to take stock, and see where things stand in the JavaScript ecosystem.
+
+  ###########################################################################
+  # Survey-Specific FAQs
+  ###########################################################################
+
+  # CSS
+
+  - key: faq.data_used_css
+    t: How will this data be used?
+  - key: faq.data_used_css.description
+    t: >
+      All data collected will be released openly for any developer or company to consult.
+      Browser vendors also [use this data](https://web.dev/interop-2023/) to prioritize focus areas and inform their roadmaps.
+
+  - key: faq.who_should_take_survey_css
+    t: Who should take this survey?
+  - key: faq.who_should_take_survey_css.description
+    t: >
+      This is an open survey for anybody who writes CSS, whether regularly
+      or occasionally, as part of their job, as a student, or just for fun!
+
+  - key: faq.survey_goals_css
+    t: What is the survey's goal?
+  - key: faq.survey_goals_css.description
+    t: >
+      The survey's goal is to track the evolution of upcoming features and libraries,
+      and help developers decide which new technologies to focus on.
+
+  # CSS 2022
+
+  - key: faq.learn_more_css2022
+    t: Where can I learn more?
+  - key: faq.learn_more_css2022.description
+    t: You can learn more about [last year's survey here](https://2021.stateofcss.com/en-US/about/).
+
+  - key: faq.survey_design_css2022
+    t: How was this survey designed?
+  - key: faq.survey_design_css2022.description
+    t: This year, thanks to a grant from Google's [UI Fund](https://web.dev/ui-fund/), [Lea Verou](https://lea.verou.me/) was able to take the lead and managed the [open survey design process](https://github.com/orgs/Devographics/projects/1/views/1) on GitHub.
+
+  - key: faq.results_released_css2022
+    t: When will the results be released?
+  - key: faq.results_released_css2022.description
+    t: The survey will run until the end of October 2022, and the survey results will be released in early November.
+
+  - key: faq.data_used_css2022
+    t: How will this data be used?
+  - key: faq.data_used_css2022.description
+    t: All data collected will be released publicly. It will then become a resources both for developers, who consult it to inform their technological choices, and browser vendors, who use it to prioritize focus areas and inform their roadmaps.
+
+  # CSS 2023
+
+  - key: faq.how_long_will_survey_take_css2023
+    t: How long will answering the survey take?
+  - key: faq.how_long_will_survey_take_css2023.description
+    t: >
+      Depending on how many questions you answer (all questions can be skipped),
+      filling out the survey should take around 10-15 minutes.
+
+  - key: faq.learn_more_css2023
+    t: Where can I learn more?
+  - key: faq.learn_more_css2023.description
+    t: You can learn more about this survey in [our announcement post](https://dev.to/sachagreif/the-2023-state-of-css-survey-is-now-open-18bk).
+
+  - key: faq.survey_design_css2023
+    t: How was this survey designed?
+  - key: faq.survey_design_css2023.description
+    t: >
+      This year, thanks to a grant from Google's [UI Fund](https://web.dev/ui-fund/),
+      [Chen Hui Jing](https://chenhuijing.com/) was able to help manage the survey's [open design process](https://github.com/Devographics/surveys/issues/84).
+
+  - key: faq.results_released_css2023
+    t: When will the results be released?
+  - key: faq.results_released_css2023.description
+    t: The survey will run until July 15, 2023, and the survey results will be released in the following weeks.
+
+  # JS 2022
+
+  - key: faq.learn_more_js2022
+    t: Where can I learn more?
+  - key: faq.learn_more_js2022.description
+    t: You can learn more about [last year's survey here](https://2021.stateofjs.com/en-US/about/).
+
+  # - key: faq.survey_design_js2022
+  #   t: How was this survey designed?
+  # - key: faq.survey_design_css2022.description
+  #   t: This year, thanks to a grant from Google's [UI Fund](https://web.dev/ui-fund/), [Lea Verou](https://lea.verou.me/) was able to take the lead and managed the [open survey design process](https://github.com/orgs/Devographics/projects/1/views/1) on GitHub.
+
+  - key: faq.results_released_js2022
+    t: When will the results be released?
+  - key: faq.results_released_js2022.description
+    t: The survey will run until December 15, 2022, and the survey results will be released shortly afterwards.
+
+  - key: faq.data_used_js2022
+    t: How will this data be used?
+  - key: faq.data_used_js2022.description
+    t: All data collected will be released publicly. It will then become a resources both for developers, who consult it to inform their technological choices, and browser vendors, who use it to prioritize focus areas and inform their roadmaps.
+
+  # HTML 2023
+
+  - key: faq.data_used_html2023
+    t: How will this data be used?
+  - key: faq.data_used_html2023.description
+    t: >
+      All data collected will be released openly for any developer or company to consult.
+      Browser vendors also [use this data](https://web.dev/interop-2023/) to prioritize focus areas and inform their roadmaps.
+
+  - key: faq.survey_goals_html2023
+    t: What are the survey's goals?
+  - key: faq.survey_goals_html2023.description
+    t: >
+      The survey's goals are to measure awareness of new HTML features and browser APIs, and help developers keep track of how their usage is evolving.
+
+  - key: faq.who_should_take_survey_html2023
+    t: Who should take this survey?
+  - key: faq.who_should_take_survey_html2023.description
+    t: >
+      This is an open survey for anybody who makes websites or web apps, whether regularly or occasionally, as part of their job, as a student, or just for fun!
+
+  - key: faq.how_long_will_survey_take_html2023
+    t: How long will answering the survey take?
+  - key: faq.how_long_will_survey_take_html2023.description
+    t: >
+      Depending on how many questions you answer (all questions are optional),
+      filling out the survey should take around 15-20 minutes.
+
+  - key: faq.learn_more_html2023
+    t: Where can I learn more?
+  - key: faq.learn_more_html2023.description
+    t: You can learn more about this survey in [our announcement post](https://lea.verou.me/blog/2023/design-state-of-html/).
+
+  - key: faq.survey_design_html2023
+    t: How was this survey designed?
+  - key: faq.survey_design_html2023.description
+    t: >
+      The survey was designed by [Lea Verou](https://lea.verou.me), with input from browser vendors as well as groups such as the [WebDX Community Group](https://www.w3.org/community/webdx/).
+
+  - key: faq.results_released_html2023
+    t: When will the results be released?
+  - key: faq.results_released_html2023.description
+    t: The survey will run from September 19 to October 16, and the survey results will be released shortly after that.
+
+  # React 2023
+
+  - key: faq.data_used_react2023
+    t: How will this data be used?
+  - key: faq.data_used_react2023.description
+    t: >
+      All data collected will be released openly for anybody to consult. Developers or companies may use it to prioritize focus areas and inform their roadmaps.
+
+  - key: faq.survey_goals_react2023
+    t: What are the survey's goals?
+  - key: faq.survey_goals_react2023.description
+    t: >
+      The survey's goals are to measure awareness and popularity of React APIs, as well as libraries in the React ecosystem.
+
+  - key: faq.who_should_take_survey_react2023
+    t: Who should take this survey?
+  - key: faq.who_should_take_survey_react2023.description
+    t: >
+      This is an open survey for anybody who uses React, whether regularly or occasionally, as part of their job, as a student, or just for fun!
+
+  - key: faq.how_long_will_survey_take_react2023
+    t: How long will answering the survey take?
+  - key: faq.how_long_will_survey_take_react2023.description
+    t: >
+      Depending on how many questions you answer (all questions are optional),
+      filling out the survey should take around 15-20 minutes.
+
+  - key: faq.learn_more_react2023
+    t: Where can I learn more?
+  - key: faq.learn_more_react2023.description
+    t: You can learn more about this survey in [our announcement post](https://dev.to/sachagreif/announcing-the-first-ever-state-of-react-survey-3k6b).
+
+  - key: faq.survey_design_react2023
+    t: How was this survey designed?
+  - key: faq.survey_design_react2023.description
+    t: >
+      The survey was designed with input from the community through an [open feedback thread](https://github.com/Devographics/surveys/issues/85).
+
+  - key: faq.results_released_react2023
+    t: When will the results be released?
+  - key: faq.results_released_react2023.description
+    t: The survey will run from October 27 to November 15, and the survey results will be released shortly after that.
+
+  # JS 2023
+
+  - key: general.js2023.survey_intro
+    t: >
+      JavaScript started its life as a browser language, and then went to on conquer the server with Node.js. 
+
+
+      And it 2023, it seems like the ecosystem as a whole might finally be ready to try and bridge that gap. Between features like React Server Components, frameworks like Solid and Qwik, or meta-frameworks like Next.js and Sveltekit, providing a better way of serving code and data to clients has become JavaScript's next big goal. 
+
+
+      Or should we say TypeScript? At this point it's become hard to disentangle the two, so let's not even try. 
+
+
+      Instead, take the survey and help us figure out what's new, what's old, and what async/awaits us in the years to come!
+
+  - key: faq.data_used_js2023
+    t: How will this data be used?
+  - key: faq.data_used_js2023.description
+    t: >
+      All data collected will be released openly for anybody to consult. Developers or companies may use it to prioritize focus areas and inform their roadmaps.
+
+  - key: faq.survey_goals_js2023
+    t: What are the survey's goals?
+  - key: faq.survey_goals_js2023.description
+    t: >
+      The survey's goals are to measure awareness and popularity of JavaScript features and libraries in order to anticipate future trends.
+
+  - key: faq.who_should_take_survey_js2023
+    t: Who should take this survey?
+  - key: faq.who_should_take_survey_js2023.description
+    t: >
+      This is an open survey for anybody who uses JavaScript (or TypeScript), whether regularly or occasionally, as part of their job, as a student, or just for fun!
+
+  - key: faq.how_long_will_survey_take_js2023
+    t: How long will answering the survey take?
+  - key: faq.how_long_will_survey_take_js2023.description
+    t: >
+      Depending on how many questions you answer (all questions are optional),
+      filling out the survey should take around 15-20 minutes.
+
+  - key: faq.learn_more_js2023
+    t: Where can I learn more?
+  - key: faq.learn_more_js2023.description
+    t: You can learn more about this survey in [our announcement post](https://dev.to/sachagreif/the-state-of-js-2023-survey-is-now-open-2hah).
+
+  - key: faq.survey_design_js2023
+    t: How was this survey designed?
+  - key: faq.survey_design_js2023.description
+    t: >
+      The survey was designed with input from the community through an [open feedback thread](https://github.com/Devographics/surveys/issues/224).
+
+  - key: faq.results_released_js2023
+    t: When will the results be released?
+  - key: faq.results_released_js2023.description
+    t: The survey will run from November 22 to December 12, and the survey results will be released shortly after that.

--- a/surveys.yml
+++ b/surveys.yml
@@ -123,13 +123,13 @@ translations:
   ###########################################################################
 
   - key: accounts.create_account
-    t: Continue with Account
+    t: アカウントを使って回答する
   - key: accounts.create_account.description
-    t: Having an account lets you **access your own data in the future** and be notified when survey results are published.
+    t: アカウントがあれば自分の回答データを見返すことができ、調査結果が公開されたタイミングで通知を受け取ることができます。
   - key: accounts.create_account.note
-    t: If you **already have an account** we will send you a magic log-in link by email.
+    t: すでにアカウントをお持ちの方には、ログインのためのメールでマジックリンクを送信します。
   - key: accounts.create_account.action
-    t: Continue with Account
+    t: アカウントを使って回答する
   - key: accounts.your_email
     t: Your Email
 
@@ -139,11 +139,11 @@ translations:
     t: Upgrading your account with an email address will let you access your survey response after you end your session.
 
   - key: accounts.continue_as_guest
-    t: Continue as Guest
+    t: ゲストとして回答する
   - key: accounts.continue_as_guest.description
-    t: Taking the survey anonymously means you **won't be able to access your data again** after you end your session.
+    t: 匿名で回答することもできますが、セッションが終了したあとは自分の回答データを見返すことはできません。
   - key: accounts.continue_as_guest.action
-    t: Continue as Guest
+    t: ゲストとして回答する
 
   - key: accounts.magic_link.no_email
     t: Please enter your email
@@ -599,54 +599,53 @@ translations:
 
   - key: general.js2023.survey_intro
     t: >
-      JavaScript started its life as a browser language, and then went to on conquer the server with Node.js. 
+      JavaScriptはブラウザで動く言語として生まれ、その後Node.jsを使ってサーバでも活躍するようになりました。 
 
 
-      And it 2023, it seems like the ecosystem as a whole might finally be ready to try and bridge that gap. Between features like React Server Components, frameworks like Solid and Qwik, or meta-frameworks like Next.js and Sveltekit, providing a better way of serving code and data to clients has become JavaScript's next big goal. 
+      そして2023年、エコシステム全体がそのギャップを埋めるための準備が整ったようにみえます。React Server Componentsのような機能や、Solid、Qwikといったフレームワーク、またNext.jsやSveltekitといったメタフレームワークでは、クライアントに対してコードとデータを提供するためのより良い手段を提供することが、JavaScriptの次なる大きな目標となっています。
 
 
-      Or should we say TypeScript? At this point it's become hard to disentangle the two, so let's not even try. 
+      あるいはTypeScriptと言うべきでしょうか？この時点では、これら二つを切り離すのは難しくなってきています。
 
 
-      Instead, take the survey and help us figure out what's new, what's old, and what async/awaits us in the years to come!
+      何が新しいか、古いか、そして今後の数年で何が私たちを待ち受けているのかを知るためにアンケートにご参加ください！
 
   - key: faq.data_used_js2023
-    t: How will this data be used?
+    t: 回答したデータはどのように使用されますか？
   - key: faq.data_used_js2023.description
     t: >
-      All data collected will be released openly for anybody to consult. Developers or companies may use it to prioritize focus areas and inform their roadmaps.
+      集めたデータはすべて公開され、誰でも参照できるようになります。開発者や企業は、これを参考にして重点分野の優先順位付けをしたり、ロードマップを立てるために役立てることができます。
 
   - key: faq.survey_goals_js2023
-    t: What are the survey's goals?
+    t: この調査の目的は何ですか？
   - key: faq.survey_goals_js2023.description
     t: >
-      The survey's goals are to measure awareness and popularity of JavaScript features and libraries in order to anticipate future trends.
+      この調査の目的はJavaScriptの機能やライブラリの認知度や人気を測定し、今後のトレンドを予測することです。
 
   - key: faq.who_should_take_survey_js2023
-    t: Who should take this survey?
+    t: このアンケートの対象者は誰ですか？
   - key: faq.who_should_take_survey_js2023.description
     t: >
-      This is an open survey for anybody who uses JavaScript (or TypeScript), whether regularly or occasionally, as part of their job, as a student, or just for fun!
+      このアンケートはJavaScript（または TypeScript）を、仕事として、学生として、あるいは単なる趣味として使っている人なら誰でも参加できるオープンなアンケートです！
 
   - key: faq.how_long_will_survey_take_js2023
-    t: How long will answering the survey take?
+    t: このアンケートの回答にはどのくらいの時間がかかりますか？
   - key: faq.how_long_will_survey_take_js2023.description
     t: >
-      Depending on how many questions you answer (all questions are optional),
-      filling out the survey should take around 15-20 minutes.
+      回答する質問の数によりますが、アンケートの所要時間は15〜20分程度です。（すべての質問は任意です）
 
   - key: faq.learn_more_js2023
-    t: Where can I learn more?
+    t: 調査についてもっと詳しく知りたいです！
   - key: faq.learn_more_js2023.description
-    t: You can learn more about this survey in [our announcement post](https://dev.to/sachagreif/the-state-of-js-2023-survey-is-now-open-2hah).
+    t: この調査についての詳細は「[The State of JS 2023 Survey is Now Open](https://dev.to/sachagreif/the-state-of-js-2023-survey-is-now-open-2hah)」をご覧ください！
 
   - key: faq.survey_design_js2023
-    t: How was this survey designed?
+    t: この調査の内容はどのように設計されていますか？
   - key: faq.survey_design_js2023.description
-    t: >
-      The survey was designed with input from the community through an [open feedback thread](https://github.com/Devographics/surveys/issues/224).
+    t:
+      この調査は「[State of JS 2023 Feedback](https://github.com/Devographics/surveys/issues/224)」を通して、コミュニティからの意見をもとに組み立てられました。
 
   - key: faq.results_released_js2023
-    t: When will the results be released?
+    t: 結果はいつ公開されますか？
   - key: faq.results_released_js2023.description
-    t: The survey will run from November 22 to December 12, and the survey results will be released shortly after that.
+    t: 調査期間は11月22日から12月12日までで、調査結果はその後まもなく公開される予定です。

--- a/surveys.yml
+++ b/surveys.yml
@@ -23,7 +23,7 @@ translations:
     t: Hidden
 
   - key: general.pick_up_to
-    t: Pick up to {limit} items.
+    t: 最大{limit}つ選択してください。
 
   - key: general.privacy_policy
     t: Privacy Policy
@@ -69,13 +69,13 @@ translations:
     t: Item {index}…
 
   - key: feature.unimplemented
-    t: No browser implementation yet
+    t: どのブラウザも未実装
 
   - key: general.skip_question
-    t: Skip
+    t: スキップ
 
   - key: general.unskip_question
-    t: Answer Question
+    t: 回答する
 
   - key: general.skip_question.description
     t: Skip question and mark it as completed
@@ -84,10 +84,10 @@ translations:
     t: Unskip question and answer it
 
   - key: years.less_than_one_year
-    t: Less than one year
+    t: 1年未満
 
   - key: years.years
-    t: years
+    t: 年
 
   - key: likert.option.0
     t: Very Unhappy
@@ -108,7 +108,7 @@ translations:
   ###########################################################################
 
   - key: error.duplicate_response
-    t: Sorry, you already have a session in progress for this survey.
+    t: ごめんなさい、このアンケートに関してすでに進行中のセッションがあるようです。
 
   - key: error.report_issue
     t: Report issue
@@ -116,7 +116,7 @@ translations:
   - key: success.data_saved
     t: Data Saved
   - key: success.data_saved.description
-    t: Your data has been saved.
+    t: 保存されました。
 
   ###########################################################################
   # Accounts
@@ -134,9 +134,9 @@ translations:
     t: Your Email
 
   - key: accounts.upgrade_account.action
-    t: Upgrade your account
+    t: アカウントをアップグレードする
   - key: accounts.upgrade_account.description
-    t: Upgrading your account with an email address will let you access your survey response after you end your session.
+    t: セッションが終了した後も自分の回答にアクセスしたい場合はメールアドレスを使用してアカウントをアップグレードしてください。
 
   - key: accounts.continue_as_guest
     t: ゲストとして回答する
@@ -238,44 +238,42 @@ translations:
 
   - key: readinglist.prompt
     t: >
-      You picked “{option}”. If you'd like to learn more about this feature at the end of the survey, you can click the "+" icon above to add it to your **reading list**.
+      あなたは “{option}” を選びました。"+"ボタンをクリックしてリーディングリストに追加すれば、アンケート終了後にこの機能についてもっと詳しく知ることができます。
 
   - key: readinglist.add_to_list
-    t: Add to Your Reading List
+    t: リーディングリストに追加する
 
   - key: readinglist.remove_from_list
-    t: Remove from Reading List
+    t: リーディングリストから削除する
 
   - key: readinglist.added_to_list
-    t: Added “{label}” to your reading list.
+    t: “{label}” をリーディングリストに追加しました。
 
   - key: readinglist.title
-    t: Reading List
+    t: リーディングリスト
 
   - key: readinglist.description
     t: >
-      Save items here using the "+" button, and you'll get a list of links to learn more about them at the end of the survey.
+      "+"ボタンをクリックしてリーディングリストに追加すれば、アンケート終了後にリンクの一覧が表示されます。
 
   - key: readinglist.empty
     t: >
-      You don't have any items in your reading list.
-      Try going back to the survey and adding features or libraries you'd like
-      to learn more about using the "+" button.
+      リーディングリストには項目がありません。アンケートに戻り、詳しく知りたい機能やライブラリの"+"ボタンをクリックして、リーディングリストに追加してみてください。
 
   - key: readinglist.results
     t: >
-      Here are some resources to learn more about the items in your reading list:
+      以下のリンクから、あなたがリーディングリストに追加した項目についてさらに学ぶことができます：
 
   - key: readinglist.homepage_link
-    t: Homepage
+    t: ホームページ
 
   - key: readinglist.receive_copy
     t: >
-      Enter your email to get a copy of your reading list straight in your inbox:
+      リーディングリストをメールで受け取るためには、メールアドレスを入力してください：
   - key: readinglist.send_by_email
-    t: Send
+    t: 送信
   - key: readinglist.email_sent
-    t: Thanks! Your reading list is on its way to your inbox.
+    t: ありがとう！あなたのリーディングリストは、あなたのメールボックスに送られています。
 
   ###########################################################################
   # Score & Knowledge Ranks
@@ -602,7 +600,7 @@ translations:
       JavaScriptはブラウザで動く言語として生まれ、その後Node.jsを使ってサーバでも活躍するようになりました。 
 
 
-      そして2023年、エコシステム全体がそのギャップを埋めるための準備が整ったようにみえます。React Server Componentsのような機能や、Solid、Qwikといったフレームワーク、またNext.jsやSveltekitといったメタフレームワークでは、クライアントに対してコードとデータを提供するためのより良い手段を提供することが、JavaScriptの次なる大きな目標となっています。
+      2023年は、エコシステム全体がそのギャップを橋渡しするための準備を整えたようにみえます。React Server Componentsのような機能や、Solid、Qwikといったフレームワーク、またNext.jsやSveltekitといったメタフレームワークでは、クライアントに対してコードとデータをより良い手段で提供することが、JavaScriptの次なる大きな目標となっています。
 
 
       あるいはTypeScriptと言うべきでしょうか？この時点では、これら二つを切り離すのは難しくなってきています。


### PR DESCRIPTION
*   While partially synchronizing with the language data in [en-US](https://github.com/Devographics/locale-en-US) 
*   Add japanese translation for [State of JavaScript 2023](https://survey.devographics.com/ja-JP/survey/state-of-js/2023) 