### PR TITLE
Fix incorrect numerical units on results page

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -196,7 +196,7 @@ translations:
     t: Twitterにシェア
   - key: thanks.share_score_message
     t: >
-      私の #{hashtag} ナレッジスコアは{score}%でした。回答はここから：{shareUrl}
+      私の #{hashtag} ナレッジスコアは{score}pointsでした。回答はここから：{shareUrl}
   # share
   - key: general.share_subject
     t: >

--- a/common.yml
+++ b/common.yml
@@ -183,7 +183,7 @@ translations:
     t: クイズスコア
   - key: thanks.score_statistics
     t: >
-      このアンケートで紹介した全 {total} 機能のうち、あなたは {usage_count} 個を使用し、 {awareness_count} 個聞いたことがあります。これは全回答者の上位{knowledgeRankingFromTop}％に位置しています。おめでとうございます！
+      このアンケートで紹介した全 {total} 機能のうち、あなたは {usage_count} 個を使用し、 {awareness_count} 個聞いたことがあります。これは全回答者の上位{knowledgeRankingFromTop}に位置しています。おめでとうございます！
   - key: thanks.score_statistics_noranking
     t: >
       このアンケートで紹介した全 {total} 機能のうち、あなたは {usage_count} 個を使用し、 {awareness_count} 個聞いたことがあります。お疲れ様でした！


### PR DESCRIPTION
## 概要

結果画面で次のような文章が表示される。

> このアンケートで紹介した全 xx 機能のうち、あなたは xx 個を使用し、 xx 個聞いたことがあります。これは全回答者の上位0.1%％に位置しています。おめでとうございます！

"％" が不要であるため削除する。

また、Twitter シェア文言は次のように表示される。

> 私の #StateOfHTML ナレッジスコアは640%でした。回答はここから：https://survey.devographics.com/survey/state-of-html/2025?source=post_survey_share

スコアの単位がおかしい。正しい単位は `points` であり、`%` ではない。

## 修正内容

```diff
diff --git a/common.yml b/common.yml
index 6c8c08f..f569464 100644
--- a/common.yml
+++ b/common.yml
@@ -183,7 +183,7 @@ translations:
     t: クイズスコア
   - key: thanks.score_statistics
     t: >
-      このアンケートで紹介した全 {total} 機能のうち、あなたは {usage_count} 個を使用し、 {awareness_count} 個聞いたことがあります。これは全回答者の上位{knowledgeRankingFromTop}％に位置しています。おめでとうございます！
+      このアンケートで紹介した全 {total} 機能のうち、あなたは {usage_count} 個を使用し、 {awareness_count} 個聞いたことがあります。これは全回答者の上位{knowledgeRankingFromTop}に位置しています。おめでとうございます！
   - key: thanks.score_statistics_noranking
     t: >
       このアンケートで紹介した全 {total} 機能のうち、あなたは {usage_count} 個を使用し、 {awareness_count} 個聞いたことがあります。お疲れ様でした！
@@ -196,7 +196,7 @@ translations:
     t: Twitterにシェア
   - key: thanks.share_score_message
     t: >
-      私の #{hashtag} ナレッジスコアは{score}%でした。回答はここから：{shareUrl}
+      私の #{hashtag} ナレッジスコアは{score}pointsでした。回答はここから：{shareUrl}
   # share
   - key: general.share_subject
     t: >
```